### PR TITLE
Fix wgpu glyph rendering

### DIFF
--- a/koharu-renderer/tests/rendering.rs
+++ b/koharu-renderer/tests/rendering.rs
@@ -65,7 +65,6 @@ fn render_horizontal() -> Result<()> {
     let img = wgpu_renderer()?.render(
         &lines,
         WritingMode::Horizontal,
-        &font,
         &RenderOptions {
             font_size: 24.0,
             padding: 0.0,
@@ -91,7 +90,6 @@ fn render_vertical() -> Result<()> {
     let img = wgpu_renderer()?.render(
         &lines,
         WritingMode::VerticalRl,
-        &font,
         &RenderOptions {
             font_size: 24.0,
             padding: 0.0,
@@ -121,7 +119,6 @@ fn vertical_flows_top_to_bottom() -> Result<()> {
     let img = wgpu_renderer()?.render(
         &layout,
         WritingMode::VerticalRl,
-        &font,
         &RenderOptions {
             font_size: 24.0,
             padding: 0.0,
@@ -160,7 +157,6 @@ fn render_horizontal_simplified_chinese() -> Result<()> {
     let img = wgpu_renderer()?.render(
         &lines,
         WritingMode::Horizontal,
-        &font,
         &RenderOptions {
             font_size: 24.0,
             padding: 0.0,
@@ -186,7 +182,6 @@ fn render_vertical_simplified_chinese() -> Result<()> {
     let img = wgpu_renderer()?.render(
         &lines,
         WritingMode::VerticalRl,
-        &font,
         &RenderOptions {
             font_size: 24.0,
             padding: 0.0,
@@ -211,7 +206,6 @@ fn render_rgba_text() -> Result<()> {
     let img = wgpu_renderer()?.render(
         &lines,
         WritingMode::Horizontal,
-        &font,
         &RenderOptions {
             font_size: 24.0,
             padding: 0.0,
@@ -223,5 +217,30 @@ fn render_rgba_text() -> Result<()> {
 
     assert!(img.pixels().any(|p| p.0 != [255, 255, 255, 255]));
     img.save(output_dir().join("rgba_text.png"))?;
+    Ok(())
+}
+
+#[test]
+#[ignore]
+fn render_with_fallback_fonts() -> Result<()> {
+    let primary_font = font("Yu Gothic")?;
+    let fallback_fonts = vec![font("Segoe UI Symbol")?, font("Segoe UI Emoji")?];
+
+    let lines = TextLayout::new(&primary_font, Some(24.0))
+        .with_fallback_fonts(&fallback_fonts)
+        .run("Here is a smiley: 😊 and a star: ★ and a heart: ♥")?;
+
+    let img = wgpu_renderer()?.render(
+        &lines,
+        WritingMode::Horizontal,
+        &RenderOptions {
+            font_size: 24.0,
+            padding: 0.0,
+            background: Some([255, 255, 255, 255]),
+            ..Default::default()
+        },
+    )?;
+    assert!(img.pixels().any(|p| p.0 != [255, 255, 255, 255]));
+    img.save(output_dir().join("fallback_fonts.png"))?;
     Ok(())
 }


### PR DESCRIPTION
# Fix Special Character Rendering with WGPU ~~and Add Text Stroke/Outline Support~~

## Overview

This PR addresses critical rendering issues introduced with the WGPU renderer migration ~~and adds a new text stroke feature to improve readability.~~

## Problem 1: Special Character Rendering

With the recent transition to the WGPU renderer, special characters such as symbols (♥, ★, etc.) and control characters (like newlines `\n`) were not being rendered correctly. Instead of displaying the intended glyphs, a generic "tofu" character (□) appeared, indicating missing glyph support.

**Before:**

<img width="58" height="76" alt="grafik" src="https://github.com/user-attachments/assets/d1e9ffb4-8b80-402e-80c4-9d9b190706c8" />

**After:**

<img width="51" height="55" alt="grafik" src="https://github.com/user-attachments/assets/77844f76-df93-4a90-bbc4-91d768fd6c9a" />

## ~~Problem 2: Text Readability on Complex Backgrounds~~

~~When rendering translated text over complex backgrounds, text often became difficult to read due to insufficient contrast between the text and background elements. The current solution is to select a custom color, but my implementation mimics the typical approach seen in manga creation by adding either a white or black outline based on font color~~

**Without Outline:**

<img width="74" height="137" alt="grafik" src="https://github.com/user-attachments/assets/36562c2a-949c-40db-adb8-bc4ccb7abb53" />

**With Outline:**

<img width="77" height="92" alt="grafik" src="https://github.com/user-attachments/assets/c5b6979e-0f23-4607-bb57-6659a9862eb7" />~~

## Solutions Implemented

### 1. Special Character Fallback Font System

- **Font Glyph Detection**: Added `has_glyph()` and `glyph_id()` methods to the `Font` struct to detect when a character is missing from the primary font (notdef glyph, ID 0)
- **Fallback Font Query System**: Implemented `query_fallback_for_char()` that searches through a prioritized list of system fonts known to contain common symbols and emoji:
  - Windows: Segoe UI Symbol, Segoe UI Emoji
  - macOS: Apple Symbols, Apple Color Emoji
  - Linux/Cross-platform: Noto Sans Symbols, Noto Color Emoji, DejaVu Sans, Symbola
  - Additional: Arial Unicode MS, Code2000
- **Per-Character Fallback**: The renderer now collects and applies fallback fonts on a per-character basis, ensuring special characters render correctly while maintaining the primary font for regular text
- **Multi-Font Atlas Support**: Extended the WGPU renderer to support multiple font atlases (primary + fallback fonts) in a single render pass

### ~~2. Text Stroke/Outline Feature~~

- ~~**Automatic Stroke Color**: Intelligent stroke color selection based on text luminance (ITU-R BT.601 formula):~~
  - Light text (luminance > 127.5) → Black outline
  - Dark text (luminance ≤ 127.5) → White outline
- ~~**Configurable Stroke Width**: Auto-calculated at 6% of font size (clamped between 1-8 pixels), with manual override support~~
- ~~**Shader Implementation**: Modified the WGPU fragment shader to render both fill and stroke in a single pass using signed distance field techniques~~
- ~~**UI Controls**: Added a toggle in the Render Controls panel (per-block or global scope)~~
- ~~**Internationalization**: Updated all translation files (en-US, ja-JP, zh-CN, zh-TW) with stroke-related strings~~

## Technical Changes

**Backend (Rust):**
- `koharu-renderer/src/font.rs`:
  - Added `has_glyph()` and `glyph_id()` for glyph existence checking
  - Implemented `query_fallback_for_char()` with platform-specific fallback font lists
- `koharu-renderer/src/renderer.rs`:
  - ~~Extended `RenderOptions` with `stroke_color` and `stroke_width` parameters~~
  - ~~Added `auto_stroke_color()` and `auto_stroke_width()` helper functions~~
  - Modified `render()` to accept multiple font atlases and handle per-character fallback
  - ~~Updated WGPU shader to support stroke rendering with separate fill/stroke alpha channels~~
- `koharu/src/renderer.rs`:
  - Implemented `collect_fallback_fonts()` to gather required fallback fonts per text block
  - Integrated fallback font rendering into the main render pipeline
- `koharu/src/state.rs`:
  - ~~Added `stroke_enabled` field to `TextStyle` struct~~