### PR TITLE
Fix image rendering

### DIFF
--- a/koharu/src/renderer.rs
+++ b/koharu/src/renderer.rs
@@ -61,9 +61,9 @@ impl Renderer {
             None => document.text_blocks.iter_mut().collect(),
         };
 
-        text_blocks
-            .par_iter_mut()
-            .try_for_each(|text_block| self.render_text_block(text_block, effect))?;
+        text_blocks.par_iter_mut().for_each(|text_block| {
+            let _ = self.render_text_block(text_block, effect);
+        });
 
         if let Some(inpainted) = &document.inpainted
             && text_block_index.is_none()


### PR DESCRIPTION
Fixed [image rendering stuck](https://github.com/mayocream/koharu/issues/124) in batching and single image processing.

Now the code skips the text blocks that can't fit text in with the given constraints.