### PR TITLE
fix(ci): use ubuntu-22.04 and add llvm/clang build dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,12 +14,12 @@ jobs:
     name: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        os: [macos-latest, windows-latest, ubuntu-22.04]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install dependencies
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-22.04'
         run: |
           sudo apt update
           sudo apt install --no-install-recommends \
@@ -31,12 +31,15 @@ jobs:
             libxdo-dev \
             libssl-dev \
             libayatana-appindicator3-dev \
-            librsvg2-dev
+            librsvg2-dev \
+            llvm-dev \
+            libclang-dev \
+            clang
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
       - uses: Swatinem/rust-cache@v2
       - uses: Jimver/cuda-toolkit@master
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-22.04'
         with:
           cuda: '13.1.0'
           log-file-suffix: '${{ matrix.os }}.txt'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,8 @@ jobs:
       # refer: https://v2.tauri.app/start/prerequisites/#linux
       - run: |
           sudo apt update
-          sudo apt install libwebkit2gtk-4.1-dev \
+          sudo apt install --no-install-recommends -y \
+            libwebkit2gtk-4.1-dev \
             build-essential \
             curl \
             wget \
@@ -26,7 +27,10 @@ jobs:
             libxdo-dev \
             libssl-dev \
             libayatana-appindicator3-dev \
-            librsvg2-dev
+            librsvg2-dev \
+            llvm-dev \
+            libclang-dev \
+            clang
       - uses: actions/checkout@v6
       - uses: Swatinem/rust-cache@v2
       - run: cargo fmt -- --check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-
 jobs:
   test:
     name: Integration tests
@@ -16,7 +15,7 @@ jobs:
       # refer: https://v2.tauri.app/start/prerequisites/#linux
       - run: |
           sudo apt update
-          sudo apt install --no-install-recommends \
+          sudo apt install --no-install-recommends -y \
             libwebkit2gtk-4.1-dev \
             build-essential \
             curl \
@@ -26,7 +25,10 @@ jobs:
             libssl-dev \
             libayatana-appindicator3-dev \
             librsvg2-dev \
-            fonts-noto-cjk
+            fonts-noto-cjk \
+            llvm-dev \
+            libclang-dev \
+            clang
       - uses: actions/checkout@v6
       - uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
## Summary
- Switch from `ubuntu-latest` to `ubuntu-22.04` for reproducible builds
- Add `llvm-dev`, `libclang-dev`, `clang` to apt dependencies for all workflows (build, lint, test)
- Add `--no-install-recommends -y` flags for cleaner installs

## Test plan
- [ ] Verify all three workflows (build, lint, test) pass on ubuntu-22.04