### PR TITLE
feat(ui): LLM multi-preset configuration

### DIFF
--- a/ui/app/(app)/settings/page.tsx
+++ b/ui/app/(app)/settings/page.tsx
@@ -29,7 +29,8 @@ import { isTauri } from '@/lib/backend'
 import { api } from '@/lib/api'
 import {
   usePreferencesStore,
-  type LocalLlmConfig,
+  getActivePresetConfig,
+  type LocalLlmPreset,
 } from '@/lib/stores/preferencesStore'
 
 const THEME_OPTIONS = [
@@ -42,80 +43,21 @@ type ApiProvider = {
   id: string
   name: string
   free_tier: boolean
-  supportsBaseUrl?: boolean
-  baseUrlPlaceholder?: string
-  supportsModelName?: boolean
-  modelNamePlaceholder?: string
-  supportsPing?: boolean
-  helperText?: string
 }
 
 const API_PROVIDERS: ApiProvider[] = [
   { id: 'openai', name: 'OpenAI', free_tier: false },
-  {
-    id: 'openai-compatible',
-    name: 'OpenAI Compatible',
-    free_tier: false,
-    supportsBaseUrl: true,
-    baseUrlPlaceholder: 'http://127.0.0.1:1234/v1',
-    supportsModelName: true,
-    modelNamePlaceholder: 'e.g. gpt-4o, deepseek-chat',
-    supportsPing: true,
-    helperText:
-      'Use LM Studio, OpenRouter, or another OpenAI-compatible endpoint.',
-  },
   { id: 'gemini', name: 'Gemini', free_tier: true },
   { id: 'claude', name: 'Claude', free_tier: false },
   { id: 'deepseek', name: 'DeepSeek', free_tier: false },
 ]
 
-const PRESET_URLS: Record<LocalLlmConfig['preset'], string> = {
-  ollama: 'http://localhost:11434/v1',
-  lmstudio: 'http://127.0.0.1:1234/v1',
-  custom: '',
-}
-
-const LLM_LANGUAGES = [
-  'en-US',
-  'zh-CN',
-  'zh-TW',
-  'ja-JP',
-  'ru-RU',
-  'es-ES',
-  'fr-FR',
-  'pt-PT',
-  'tr-TR',
-  'ar-SA',
-  'ko-KR',
-  'th-TH',
-  'it-IT',
-  'de-DE',
-  'vi-VN',
-  'ms-MY',
-  'id-ID',
-  'fil-PH',
-  'hi-IN',
-  'pl-PL',
-  'cs-CZ',
-  'nl-NL',
-  'km-KH',
-  'my-MM',
-  'fa-IR',
-  'gu-IN',
-  'ur-PK',
-  'te-IN',
-  'mr-IN',
-  'he-IL',
-  'bn-BD',
-  'bg-BG',
-  'ta-IN',
-  'uk-UA',
-  'bo-CN',
-  'kk-KZ',
-  'mn-MN',
-  'ug-CN',
-  'yue-HK',
-] as const
+const PRESET_BUTTONS: { value: LocalLlmPreset; labelKey: string }[] = [
+  { value: 'ollama', labelKey: 'settings.localLlmPresetOllama' },
+  { value: 'lmstudio', labelKey: 'settings.localLlmPresetLmStudio' },
+  { value: 'preset1', labelKey: 'settings.localLlmPresetPreset1' },
+  { value: 'preset2', labelKey: 'settings.localLlmPresetPreset2' },
+]
 
 const DEFAULT_SYSTEM_PROMPT =
   'You are a professional manga translator. Translate Japanese manga dialogue into natural {target_language} that fits inside speech bubbles. Preserve character voice, emotional tone, relationship nuance, emphasis, and sound effects naturally. Keep the wording concise. Do not add notes, explanations, or romanization. If the input contains <block id="N">...</block>, translate only the text inside each block. Keep every block tag exactly unchanged, including ids, order, and block count. Do not merge blocks, split blocks, or add any text outside the blocks.'
@@ -132,21 +74,10 @@ export default function SettingsPage() {
   )
   const [deviceInfo, setDeviceInfo] = useState<{ mlDevice: string }>()
   const apiKeys = usePreferencesStore((state) => state.apiKeys)
-  const providerBaseUrls = usePreferencesStore(
-    (state) => state.providerBaseUrls,
-  )
   const setApiKey = usePreferencesStore((state) => state.setApiKey)
-  const setProviderBaseUrl = usePreferencesStore(
-    (state) => state.setProviderBaseUrl,
-  )
   const localLlm = usePreferencesStore((state) => state.localLlm)
   const setLocalLlm = usePreferencesStore((state) => state.setLocalLlm)
-  const providerModelNames = usePreferencesStore(
-    (state) => state.providerModelNames,
-  )
-  const setProviderModelName = usePreferencesStore(
-    (state) => state.setProviderModelName,
-  )
+  const setActivePreset = usePreferencesStore((state) => state.setActivePreset)
   const [visibleKeys, setVisibleKeys] = useState<Record<string, boolean>>({})
   const saveTimersRef = useRef<Record<string, ReturnType<typeof setTimeout>>>(
     {},
@@ -158,20 +89,8 @@ export default function SettingsPage() {
     loading: boolean
     result?: { ok: boolean; count: number; latency: number; error?: string }
   }>({ loading: false })
-  const [providerPingState, setProviderPingState] = useState<
-    Record<
-      string,
-      {
-        loading: boolean
-        result?: {
-          ok: boolean
-          count: number
-          latency: number
-          error?: string
-        }
-      }
-    >
-  >({})
+
+  const activeConfig = getActivePresetConfig(localLlm)
 
   useEffect(() => {
     if (!isTauri()) return
@@ -235,16 +154,12 @@ export default function SettingsPage() {
     }, 300)
   }
 
-  const handlePresetChange = (preset: LocalLlmConfig['preset']) => {
-    setLocalLlm({ preset, baseUrl: PRESET_URLS[preset] || localLlm.baseUrl })
-  }
-
   const handleTestConnection = async () => {
     setPingState({ loading: true })
     try {
       const result = await api.llmPing(
-        localLlm.baseUrl,
-        localLlm.apiKey || undefined,
+        activeConfig.baseUrl,
+        activeConfig.apiKey || undefined,
       )
       setPingState({
         loading: false,
@@ -268,44 +183,9 @@ export default function SettingsPage() {
     }
   }
 
-  const handleProviderPing = async (providerId: string) => {
-    const baseUrl = providerBaseUrls[providerId]?.trim()
-    if (!baseUrl) return
-    setProviderPingState((prev) => ({
-      ...prev,
-      [providerId]: { loading: true },
-    }))
-    try {
-      const result = await api.llmPing(
-        baseUrl,
-        apiKeys[providerId] || undefined,
-      )
-      setProviderPingState((prev) => ({
-        ...prev,
-        [providerId]: {
-          loading: false,
-          result: {
-            ok: result.ok,
-            count: result.models.length,
-            latency: result.latencyMs ?? 0,
-            error: result.error,
-          },
-        },
-      }))
-    } catch (error) {
-      setProviderPingState((prev) => ({
-        ...prev,
-        [providerId]: {
-          loading: false,
-          result: {
-            ok: false,
-            count: 0,
-            latency: 0,
-            error: String(error),
-          },
-        },
-      }))
-    }
+  const handlePresetChange = (preset: LocalLlmPreset) => {
+    setActivePreset(preset)
+    setPingState({ loading: false })
   }
 
   return (
@@ -417,141 +297,51 @@ export default function SettingsPage() {
                 {t('settings.apiKeysDescription')}
               </p>
               <div className='space-y-3'>
-                {API_PROVIDERS.map(
-                  ({
-                    id,
-                    name,
-                    free_tier,
-                    supportsBaseUrl,
-                    baseUrlPlaceholder,
-                    supportsModelName,
-                    modelNamePlaceholder,
-                    supportsPing,
-                    helperText,
-                  }) => (
-                    <div key={id} className='space-y-1'>
-                      <label className='text-foreground text-sm'>{name}</label>
-                      <div className='space-y-1'>
-                        {supportsBaseUrl && (
-                          <input
-                            type='url'
-                            value={providerBaseUrls[id] ?? ''}
-                            onChange={(e) =>
-                              setProviderBaseUrl(id, e.target.value)
-                            }
-                            placeholder={baseUrlPlaceholder}
-                            className={inputClass}
-                          />
-                        )}
-                        <div className='relative'>
-                          <input
-                            type={visibleKeys[id] ? 'text' : 'password'}
-                            value={apiKeys[id] ?? ''}
-                            onChange={(e) =>
-                              handleApiKeyChange(id, e.target.value)
-                            }
-                            onBlur={() => flushApiKeySave(id)}
-                            placeholder='Enter API key'
-                            className={`${inputClass} pr-9`}
-                          />
-                          <button
-                            type='button'
-                            onClick={() =>
-                              setVisibleKeys((v) => ({ ...v, [id]: !v[id] }))
-                            }
-                            className='text-muted-foreground hover:text-foreground absolute top-1/2 right-2.5 -translate-y-1/2 transition'
-                          >
-                            {visibleKeys[id] ? (
-                              <EyeOffIcon className='size-4' />
-                            ) : (
-                              <EyeIcon className='size-4' />
-                            )}
-                          </button>
-                        </div>
-
-                        {supportsModelName && (
-                          <input
-                            type='text'
-                            value={providerModelNames[id] ?? ''}
-                            onChange={(e) =>
-                              setProviderModelName(id, e.target.value)
-                            }
-                            placeholder={modelNamePlaceholder}
-                            className={inputClass}
-                          />
-                        )}
-
-                        {helperText && (
-                          <span className='ml-2 text-xs text-slate-500'>
-                            {helperText}
-                          </span>
-                        )}
-
-                        {free_tier && (
-                          <span className='ml-2 text-xs text-green-500'>
-                            {t('settings.freeTier')}
-                          </span>
-                        )}
-
-                        {supportsPing && (
-                          <div className='space-y-1 pt-1'>
-                            <button
-                              onClick={() => handleProviderPing(id)}
-                              disabled={
-                                !providerBaseUrls[id]?.trim() ||
-                                providerPingState[id]?.loading
-                              }
-                              className='border-border bg-card text-foreground hover:bg-muted inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm transition disabled:cursor-not-allowed disabled:opacity-50'
-                            >
-                              {providerPingState[id]?.loading ? (
-                                <>
-                                  <LoaderIcon className='size-3.5 animate-spin' />
-                                  {t('settings.localLlmTesting')}
-                                </>
-                              ) : (
-                                t('settings.localLlmTestConnection')
-                              )}
-                            </button>
-                            {providerPingState[id]?.result && (
-                              <div className='flex items-start gap-1.5 text-xs'>
-                                {providerPingState[id].result!.ok ? (
-                                  <>
-                                    <CheckCircleIcon className='mt-0.5 size-3.5 shrink-0 text-green-500' />
-                                    <span className='text-green-600 dark:text-green-400'>
-                                      {t('settings.localLlmTestSuccess', {
-                                        count:
-                                          providerPingState[id].result!.count,
-                                        latency:
-                                          providerPingState[id].result!.latency,
-                                      })}
-                                    </span>
-                                  </>
-                                ) : (
-                                  <>
-                                    <XCircleIcon className='mt-0.5 size-3.5 shrink-0 text-red-500' />
-                                    <span className='text-red-600 dark:text-red-400'>
-                                      {t('settings.localLlmTestFailed', {
-                                        error:
-                                          providerPingState[id].result!.error,
-                                      })}
-                                    </span>
-                                  </>
-                                )}
-                              </div>
-                            )}
-                          </div>
-                        )}
+                {API_PROVIDERS.map(({ id, name, free_tier }) => (
+                  <div key={id} className='space-y-1'>
+                    <label className='text-foreground text-sm'>{name}</label>
+                    <div className='space-y-1'>
+                      <div className='relative'>
+                        <input
+                          type={visibleKeys[id] ? 'text' : 'password'}
+                          value={apiKeys[id] ?? ''}
+                          onChange={(e) =>
+                            handleApiKeyChange(id, e.target.value)
+                          }
+                          onBlur={() => flushApiKeySave(id)}
+                          placeholder='Enter API key'
+                          className={`${inputClass} pr-9`}
+                        />
+                        <button
+                          type='button'
+                          onClick={() =>
+                            setVisibleKeys((v) => ({ ...v, [id]: !v[id] }))
+                          }
+                          className='text-muted-foreground hover:text-foreground absolute top-1/2 right-2.5 -translate-y-1/2 transition'
+                        >
+                          {visibleKeys[id] ? (
+                            <EyeOffIcon className='size-4' />
+                          ) : (
+                            <EyeIcon className='size-4' />
+                          )}
+                        </button>
                       </div>
+
+                      {free_tier && (
+                        <span className='ml-2 text-xs text-green-500'>
+                          {t('settings.freeTier')}
+                        </span>
+                      )}
                     </div>
-                  ),
-                )}
+                  </div>
+                ))}
               </div>
             </section>
 
-            {/* Local LLM Section */}
+            {/* Local LLM & OpenAI Compatible Providers Section */}
             <section className='mb-8'>
               <h2 className='text-foreground mb-1 text-sm font-bold'>
-                {t('settings.localLlm')}
+                {t('settings.localLlmTitle')}
               </h2>
               <p className='text-muted-foreground mb-4 text-sm'>
                 {t('settings.localLlmDescription')}
@@ -563,28 +353,13 @@ export default function SettingsPage() {
                   <label className='text-foreground text-sm'>
                     {t('settings.localLlmPreset')}
                   </label>
-                  <div className='flex gap-2'>
-                    {(
-                      [
-                        {
-                          value: 'ollama',
-                          labelKey: 'settings.localLlmPresetOllama',
-                        },
-                        {
-                          value: 'lmstudio',
-                          labelKey: 'settings.localLlmPresetLmStudio',
-                        },
-                        {
-                          value: 'custom',
-                          labelKey: 'settings.localLlmPresetCustom',
-                        },
-                      ] as const
-                    ).map(({ value, labelKey }) => (
+                  <div className='grid grid-cols-4 gap-2'>
+                    {PRESET_BUTTONS.map(({ value, labelKey }) => (
                       <button
                         key={value}
                         onClick={() => handlePresetChange(value)}
-                        data-active={localLlm.preset === value}
-                        className='border-border bg-card text-muted-foreground hover:border-foreground/30 data-[active=true]:border-primary data-[active=true]:text-foreground flex-1 rounded-lg border px-3 py-2 text-sm font-medium transition'
+                        data-active={localLlm.activePreset === value}
+                        className='border-border bg-card text-muted-foreground hover:border-foreground/30 data-[active=true]:border-primary data-[active=true]:text-foreground rounded-lg border px-3 py-2 text-sm font-medium transition'
                       >
                         {t(labelKey)}
                       </button>
@@ -599,9 +374,9 @@ export default function SettingsPage() {
                   </label>
                   <input
                     type='url'
-                    value={localLlm.baseUrl}
+                    value={activeConfig.baseUrl}
                     onChange={(e) => setLocalLlm({ baseUrl: e.target.value })}
-                    placeholder={PRESET_URLS[localLlm.preset]}
+                    placeholder='http://127.0.0.1:1234/v1'
                     className={inputClass}
                   />
                 </div>
@@ -613,8 +388,12 @@ export default function SettingsPage() {
                   </label>
                   <div className='relative'>
                     <input
-                      type={visibleKeys['local-llm-key'] ? 'text' : 'password'}
-                      value={localLlm.apiKey}
+                      type={
+                        visibleKeys[`llm-${localLlm.activePreset}`]
+                          ? 'text'
+                          : 'password'
+                      }
+                      value={activeConfig.apiKey}
                       onChange={(e) => setLocalLlm({ apiKey: e.target.value })}
                       placeholder='API key'
                       className={`${inputClass} pr-9`}
@@ -624,12 +403,13 @@ export default function SettingsPage() {
                       onClick={() =>
                         setVisibleKeys((v) => ({
                           ...v,
-                          'local-llm-key': !v['local-llm-key'],
+                          [`llm-${localLlm.activePreset}`]:
+                            !v[`llm-${localLlm.activePreset}`],
                         }))
                       }
                       className='text-muted-foreground hover:text-foreground absolute top-1/2 right-2.5 -translate-y-1/2 transition'
                     >
-                      {visibleKeys['local-llm-key'] ? (
+                      {visibleKeys[`llm-${localLlm.activePreset}`] ? (
                         <EyeOffIcon className='size-4' />
                       ) : (
                         <EyeIcon className='size-4' />
@@ -645,35 +425,11 @@ export default function SettingsPage() {
                   </label>
                   <input
                     type='text'
-                    value={localLlm.modelName}
+                    value={activeConfig.modelName}
                     onChange={(e) => setLocalLlm({ modelName: e.target.value })}
                     placeholder={t('settings.localLlmModelNamePlaceholder')}
                     className={inputClass}
                   />
-                </div>
-
-                {/* Target Language */}
-                <div className='space-y-1'>
-                  <label className='text-foreground text-sm'>
-                    {t('settings.localLlmTargetLanguage')}
-                  </label>
-                  <Select
-                    value={localLlm.targetLanguage}
-                    onValueChange={(value) =>
-                      setLocalLlm({ targetLanguage: value })
-                    }
-                  >
-                    <SelectTrigger className='w-full'>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {LLM_LANGUAGES.map((code) => (
-                        <SelectItem key={code} value={code}>
-                          {t(`llm.languages.${code}`)}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
                 </div>
 
                 {/* Advanced Section Toggle */}
@@ -697,7 +453,7 @@ export default function SettingsPage() {
                       </label>
                       <input
                         type='number'
-                        value={localLlm.temperature ?? ''}
+                        value={activeConfig.temperature ?? ''}
                         onChange={(e) =>
                           setLocalLlm({
                             temperature:
@@ -723,7 +479,7 @@ export default function SettingsPage() {
                       </label>
                       <input
                         type='number'
-                        value={localLlm.maxTokens ?? ''}
+                        value={activeConfig.maxTokens ?? ''}
                         onChange={(e) =>
                           setLocalLlm({
                             maxTokens:
@@ -745,7 +501,7 @@ export default function SettingsPage() {
                         <label className='text-foreground text-sm'>
                           {t('settings.localLlmSystemPrompt')}
                         </label>
-                        {localLlm.customSystemPrompt && (
+                        {activeConfig.customSystemPrompt && (
                           <button
                             type='button'
                             onClick={() =>
@@ -758,7 +514,7 @@ export default function SettingsPage() {
                         )}
                       </div>
                       <textarea
-                        value={localLlm.customSystemPrompt}
+                        value={activeConfig.customSystemPrompt}
                         onChange={(e) =>
                           setLocalLlm({
                             customSystemPrompt: e.target.value,
@@ -780,7 +536,7 @@ export default function SettingsPage() {
                   <button
                     type='button'
                     onClick={handleTestConnection}
-                    disabled={pingState.loading || !localLlm.baseUrl.trim()}
+                    disabled={pingState.loading || !activeConfig.baseUrl.trim()}
                     className='border-border bg-card text-foreground hover:bg-accent disabled:text-muted-foreground inline-flex items-center gap-2 rounded-md border px-4 py-1.5 text-sm font-medium transition disabled:opacity-50'
                   >
                     {pingState.loading ? (

--- a/ui/components/canvas/CanvasToolbar.tsx
+++ b/ui/components/canvas/CanvasToolbar.tsx
@@ -30,6 +30,7 @@ import {
   useLlmModelsQuery,
   useLlmReadyQuery,
   LOCAL_LLM_PRESET_LABELS,
+  parsePresetFromModelId,
 } from '@/lib/query/hooks'
 import { useDocumentMutations, useLlmMutations } from '@/lib/query/mutations'
 import { useOperationStore } from '@/lib/stores/operationStore'
@@ -266,21 +267,37 @@ function LlmStatusPopover() {
                   data-testid={`llm-model-option-${index}`}
                 >
                   <span className='flex items-center gap-2'>
-                    {model.source === 'openai-compatible' &&
-                    model.origin === 'local-llm' ? (
-                      <span className='rounded bg-emerald-500/10 px-1 py-0.5 text-[10px] leading-none font-semibold text-emerald-600 uppercase dark:text-emerald-400'>
-                        {LOCAL_LLM_PRESET_LABELS[localLlm.preset] ?? 'Local'}
-                      </span>
-                    ) : model.source === 'openai-compatible' ? (
-                      <span className='rounded bg-teal-500/10 px-1 py-0.5 text-[10px] leading-none font-semibold text-teal-600 uppercase dark:text-teal-400'>
-                        OpenAI-like
-                      </span>
+                    {model.source === 'openai-compatible' ? (
+                      (() => {
+                        const preset = parsePresetFromModelId(model.id)
+                        const isTeal =
+                          preset === 'preset1' || preset === 'preset2'
+                        return (
+                          <span
+                            className={`rounded px-1 py-0.5 text-[10px] leading-none font-semibold uppercase ${
+                              isTeal
+                                ? 'bg-teal-500/10 text-teal-600 dark:text-teal-400'
+                                : 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400'
+                            }`}
+                          >
+                            {preset
+                              ? (LOCAL_LLM_PRESET_LABELS[preset] ?? preset)
+                              : 'OpenAI-like'}
+                          </span>
+                        )
+                      })()
                     ) : model.source !== 'local' ? (
                       <span className='bg-primary/10 text-primary rounded px-1 py-0.5 text-[10px] leading-none font-semibold uppercase'>
                         {getProviderDisplayName(model.source)}
                       </span>
                     ) : null}
-                    {model.id.includes(':') ? model.id.split(':')[1] : model.id}
+                    {/* Display model name: strip "openai-compatible:preset:" prefix */}
+                    {model.source === 'openai-compatible' &&
+                    model.id.split(':').length >= 3
+                      ? model.id.split(':').slice(2).join(':')
+                      : model.id.includes(':')
+                        ? model.id.split(':')[1]
+                        : model.id}
                   </span>
                 </SelectItem>
               ))}
@@ -297,49 +314,59 @@ function LlmStatusPopover() {
           )}
 
           {/* Loaded model info card */}
-          {llmReady && selectedModelInfo?.source === 'openai-compatible' && (
-            <div
-              className={`rounded-md px-2.5 py-2 text-xs ${
-                selectedModelInfo.origin === 'local-llm'
-                  ? 'border border-emerald-500/20 bg-emerald-500/5'
-                  : 'border border-teal-500/20 bg-teal-500/5'
-              }`}
-            >
-              <div className='flex items-center gap-1.5'>
-                <span
-                  className={`size-1.5 rounded-full ${
-                    selectedModelInfo.origin === 'local-llm'
-                      ? 'bg-emerald-500'
-                      : 'bg-teal-500'
-                  }`}
-                />
-                <span
-                  className={`font-medium ${
-                    selectedModelInfo.origin === 'local-llm'
-                      ? 'text-emerald-700 dark:text-emerald-400'
-                      : 'text-teal-700 dark:text-teal-400'
+          {llmReady &&
+            selectedModelInfo?.source === 'openai-compatible' &&
+            (() => {
+              const infoPreset = parsePresetFromModelId(selectedModelInfo.id)
+              const isTeal =
+                infoPreset === 'preset1' || infoPreset === 'preset2'
+              const presetLabel = infoPreset
+                ? (LOCAL_LLM_PRESET_LABELS[infoPreset] ?? infoPreset)
+                : 'OpenAI-like'
+              const presetCfg = infoPreset
+                ? localLlm.presets[infoPreset]
+                : undefined
+              const modelName =
+                selectedModelInfo.id.split(':').length >= 3
+                  ? selectedModelInfo.id.split(':').slice(2).join(':')
+                  : (selectedModelInfo.id.split(':')[1] ?? selectedModelInfo.id)
+              return (
+                <div
+                  className={`rounded-md px-2.5 py-2 text-xs ${
+                    isTeal
+                      ? 'border border-teal-500/20 bg-teal-500/5'
+                      : 'border border-emerald-500/20 bg-emerald-500/5'
                   }`}
                 >
-                  {t('llm.localModelActive')}
-                </span>
-              </div>
-              <p className='text-muted-foreground mt-1'>
-                {t('llm.localModelName', {
-                  name:
-                    selectedModelInfo.id.split(':')[1] ?? selectedModelInfo.id,
-                })}
-              </p>
-              <p className='text-muted-foreground mt-0.5'>
-                {selectedModelInfo.origin === 'local-llm'
-                  ? (LOCAL_LLM_PRESET_LABELS[localLlm.preset] ?? 'Local')
-                  : 'OpenAI-like'}
-                {localLlm.temperature != null &&
-                  ` · temp ${localLlm.temperature}`}
-                {localLlm.maxTokens != null &&
-                  ` · ${localLlm.maxTokens} tokens`}
-              </p>
-            </div>
-          )}
+                  <div className='flex items-center gap-1.5'>
+                    <span
+                      className={`size-1.5 rounded-full ${
+                        isTeal ? 'bg-teal-500' : 'bg-emerald-500'
+                      }`}
+                    />
+                    <span
+                      className={`font-medium ${
+                        isTeal
+                          ? 'text-teal-700 dark:text-teal-400'
+                          : 'text-emerald-700 dark:text-emerald-400'
+                      }`}
+                    >
+                      {t('llm.localModelActive')}
+                    </span>
+                  </div>
+                  <p className='text-muted-foreground mt-1'>
+                    {t('llm.localModelName', { name: modelName })}
+                  </p>
+                  <p className='text-muted-foreground mt-0.5'>
+                    {presetLabel}
+                    {presetCfg?.temperature != null &&
+                      ` · temp ${presetCfg.temperature}`}
+                    {presetCfg?.maxTokens != null &&
+                      ` · ${presetCfg.maxTokens} tokens`}
+                  </p>
+                </div>
+              )
+            })()}
 
           {activeLanguages.length > 0 && (
             <Select

--- a/ui/lib/query/hooks.ts
+++ b/ui/lib/query/hooks.ts
@@ -6,14 +6,19 @@ import { api } from '@/lib/api'
 import { queryKeys } from '@/lib/query/keys'
 import { useEditorUiStore } from '@/lib/stores/editorUiStore'
 import { useLlmUiStore } from '@/lib/stores/llmUiStore'
-import { usePreferencesStore } from '@/lib/stores/preferencesStore'
+import {
+  usePreferencesStore,
+  ALL_PRESETS,
+  type LocalLlmPreset,
+} from '@/lib/stores/preferencesStore'
 import type { LlmModelInfo } from '@/lib/generated/protocol/LlmModelInfo'
 import i18n from '@/lib/i18n'
 import { useRpcConnection } from '@/hooks/useRpcConnection'
 
 /** Frontend-extended model entry with origin tracking. */
 export type LlmModelEntry = LlmModelInfo & {
-  origin?: 'local-llm' | 'openai-api'
+  /** Which local-llm preset this model belongs to (undefined for cloud models). */
+  originPreset?: LocalLlmPreset
 }
 
 export const useDocumentsCountQuery = (enabled = true) =>
@@ -69,19 +74,12 @@ export const useFontsQuery = () =>
 export const useLlmModelsQuery = () => {
   const [language, setLanguage] = useState(i18n.language)
   const rpcConnected = useRpcConnection()
-  const providerBaseUrl = usePreferencesStore(
-    (state) => state.providerBaseUrls['openai-compatible']?.trim() ?? '',
+  const localLlmPresets = usePreferencesStore((state) => state.localLlm.presets)
+  const hasCompatible = ALL_PRESETS.some(
+    (p) =>
+      localLlmPresets[p].baseUrl?.trim() &&
+      localLlmPresets[p].modelName?.trim(),
   )
-  const localLlmBaseUrl = usePreferencesStore(
-    (state) => state.localLlm.baseUrl?.trim() ?? '',
-  )
-  const localLlmModelName = usePreferencesStore(
-    (state) => state.localLlm.modelName?.trim() ?? '',
-  )
-  const manualModelName = usePreferencesStore(
-    (state) => state.providerModelNames?.['openai-compatible']?.trim() ?? '',
-  )
-  const hasCompatible = !!(providerBaseUrl || localLlmBaseUrl)
   const compatibleConfigVersion = usePreferencesStore(
     (state) => state.openAiCompatibleConfigVersion,
   )
@@ -109,29 +107,21 @@ export const useLlmModelsQuery = () => {
         models.find((m) => m.source !== 'local' && m.languages.length > 0)
           ?.languages ?? []
 
-      // Local LLM (Ollama / LM Studio)
-      if (localLlmModelName && localLlmBaseUrl) {
-        const id = `openai-compatible:${localLlmModelName}`
-        if (!models.some((m) => m.id === id)) {
-          models.push({
-            id,
-            languages: apiLanguages,
-            source: 'openai-compatible',
-            origin: 'local-llm',
-          })
-        }
-      }
-
-      // OpenAI Compatible (API Keys section)
-      if (manualModelName && providerBaseUrl) {
-        const id = `openai-compatible:${manualModelName}`
-        if (!models.some((m) => m.id === id)) {
-          models.push({
-            id,
-            languages: apiLanguages,
-            source: 'openai-compatible',
-            origin: 'openai-api',
-          })
+      // Inject a model entry for each preset that has baseUrl + modelName
+      for (const preset of ALL_PRESETS) {
+        const cfg = localLlmPresets[preset]
+        const baseUrl = cfg.baseUrl?.trim()
+        const modelName = cfg.modelName?.trim()
+        if (baseUrl && modelName) {
+          const id = `openai-compatible:${preset}:${modelName}`
+          if (!models.some((m) => m.id === id)) {
+            models.push({
+              id,
+              languages: apiLanguages,
+              source: 'openai-compatible',
+              originPreset: preset,
+            })
+          }
         }
       }
 
@@ -146,7 +136,32 @@ export const useLlmModelsQuery = () => {
 export const LOCAL_LLM_PRESET_LABELS: Record<string, string> = {
   ollama: 'Ollama',
   lmstudio: 'LM Studio',
-  custom: 'Local',
+  preset1: 'Preset 1',
+  preset2: 'Preset 2',
+}
+
+/** Extract the preset from a model ID like "openai-compatible:preset1:modelName". */
+export const parsePresetFromModelId = (
+  modelId: string,
+): LocalLlmPreset | undefined => {
+  const parts = modelId.split(':')
+  if (parts[0] === 'openai-compatible' && parts.length >= 3) {
+    const preset = parts[1] as LocalLlmPreset
+    if (ALL_PRESETS.includes(preset)) return preset
+  }
+  return undefined
+}
+
+/**
+ * Convert frontend model ID (openai-compatible:preset1:modelName)
+ * to backend format (openai-compatible:modelName).
+ */
+export const toBackendModelId = (modelId: string): string => {
+  if (parsePresetFromModelId(modelId)) {
+    const parts = modelId.split(':')
+    return [parts[0], ...parts.slice(2)].join(':')
+  }
+  return modelId
 }
 
 export const useApiKeyQuery = (provider: string, enabled = true) =>
@@ -159,9 +174,10 @@ export const useApiKeyQuery = (provider: string, enabled = true) =>
 
 export const useLlmReadyQuery = () => {
   const selectedModel = useLlmUiStore((state) => state.selectedModel)
+  const backendId = selectedModel ? toBackendModelId(selectedModel) : undefined
   return useQuery({
     queryKey: queryKeys.llm.ready(selectedModel),
-    queryFn: () => api.llmReady(selectedModel),
+    queryFn: () => api.llmReady(backendId),
     enabled: !!selectedModel,
   })
 }

--- a/ui/lib/query/mutations.ts
+++ b/ui/lib/query/mutations.ts
@@ -8,7 +8,12 @@ import { InpaintRegion, TextBlock } from '@/types'
 import { useEditorUiStore } from '@/lib/stores/editorUiStore'
 import { useLlmUiStore } from '@/lib/stores/llmUiStore'
 import { useOperationStore } from '@/lib/stores/operationStore'
-import { usePreferencesStore } from '@/lib/stores/preferencesStore'
+import {
+  usePreferencesStore,
+  ALL_PRESETS,
+  type LocalLlmPresetConfig,
+  type LocalLlmPreset,
+} from '@/lib/stores/preferencesStore'
 import { queryKeys } from '@/lib/query/keys'
 import {
   clearMaskSync,
@@ -75,27 +80,47 @@ const pickLanguage = (
 }
 
 const hasCompatibleConfig = () => {
-  const state = usePreferencesStore.getState()
-  return !!(
-    state.providerBaseUrls['openai-compatible']?.trim() ||
-    state.localLlm.baseUrl?.trim()
+  const { presets } = usePreferencesStore.getState().localLlm
+  return ALL_PRESETS.some(
+    (p) => presets[p].baseUrl?.trim() && presets[p].modelName?.trim(),
   )
 }
 
-const getBaseUrlForModel = (modelId: string) => {
-  const state = usePreferencesStore.getState()
-  const modelName = modelId.includes(':') ? modelId.split(':')[1] : modelId
-  if (
-    state.localLlm.modelName?.trim() === modelName &&
-    state.localLlm.baseUrl?.trim()
-  ) {
-    return state.localLlm.baseUrl.trim()
+/** Extract the preset from a model ID like "openai-compatible:preset1:modelName". */
+const resolvePresetFromModelId = (
+  modelId: string,
+): LocalLlmPreset | undefined => {
+  const parts = modelId.split(':')
+  if (parts[0] === 'openai-compatible' && parts.length >= 3) {
+    const preset = parts[1] as LocalLlmPreset
+    if (ALL_PRESETS.includes(preset)) return preset
   }
-  return (
-    state.providerBaseUrls['openai-compatible']?.trim() ||
-    state.localLlm.baseUrl?.trim() ||
-    undefined
-  )
+  return undefined
+}
+
+const getPresetConfigForModel = (
+  modelId: string,
+): LocalLlmPresetConfig | undefined => {
+  const preset = resolvePresetFromModelId(modelId)
+  if (!preset) return undefined
+  return usePreferencesStore.getState().localLlm.presets[preset]
+}
+
+const getBaseUrlForModel = (modelId: string) => {
+  const cfg = getPresetConfigForModel(modelId)
+  return cfg?.baseUrl?.trim() || undefined
+}
+
+/**
+ * Convert frontend model ID (openai-compatible:preset1:modelName)
+ * to backend format (openai-compatible:modelName).
+ */
+const toBackendModelId = (modelId: string): string => {
+  if (resolvePresetFromModelId(modelId)) {
+    const parts = modelId.split(':')
+    return [parts[0], ...parts.slice(2)].join(':')
+  }
+  return modelId
 }
 
 const getCachedLlmModels = (queryClient: QueryClient) =>
@@ -531,26 +556,28 @@ export const useDocumentMutations = () => {
         const models = getCachedLlmModels(queryClient)
         const modelInfo = models.find((m) => m.id === selectedModel)
         const language = selectedLanguage
-        const llmApiKey =
-          modelInfo && modelInfo.source !== 'local'
+        const presetCfg = selectedModel
+          ? getPresetConfigForModel(selectedModel)
+          : undefined
+        const llmApiKey = presetCfg
+          ? presetCfg.apiKey || undefined
+          : modelInfo && modelInfo.source !== 'local'
             ? usePreferencesStore.getState().apiKeys[modelInfo.source]
             : undefined
         const llmBaseUrl =
           modelInfo?.source === 'openai-compatible'
             ? getBaseUrlForModel(selectedModel!)
             : undefined
-        const localLlm = usePreferencesStore.getState().localLlm
-        const isLocalCompat = modelInfo?.source === 'openai-compatible'
         await api.process({
           index: resolvedIndex,
-          llmModelId: selectedModel,
+          llmModelId: selectedModel
+            ? toBackendModelId(selectedModel)
+            : selectedModel,
           llmApiKey,
           llmBaseUrl,
-          llmTemperature: isLocalCompat ? localLlm.temperature : undefined,
-          llmMaxTokens: isLocalCompat ? localLlm.maxTokens : undefined,
-          llmCustomSystemPrompt: isLocalCompat
-            ? localLlm.customSystemPrompt
-            : undefined,
+          llmTemperature: presetCfg?.temperature ?? undefined,
+          llmMaxTokens: presetCfg?.maxTokens ?? undefined,
+          llmCustomSystemPrompt: presetCfg?.customSystemPrompt || undefined,
           language,
           shaderEffect: renderEffect,
           shaderStroke: renderStroke,
@@ -582,25 +609,27 @@ export const useDocumentMutations = () => {
       const models = getCachedLlmModels(queryClient)
       const modelInfo = models.find((m) => m.id === selectedModel)
       const language = selectedLanguage
-      const llmApiKey =
-        modelInfo && modelInfo.source !== 'local'
+      const presetCfg2 = selectedModel
+        ? getPresetConfigForModel(selectedModel)
+        : undefined
+      const llmApiKey = presetCfg2
+        ? presetCfg2.apiKey || undefined
+        : modelInfo && modelInfo.source !== 'local'
           ? usePreferencesStore.getState().apiKeys[modelInfo.source]
           : undefined
       const llmBaseUrl =
         modelInfo?.source === 'openai-compatible'
           ? getBaseUrlForModel(selectedModel!)
           : undefined
-      const localLlm = usePreferencesStore.getState().localLlm
-      const isLocalCompat = modelInfo?.source === 'openai-compatible'
       await api.process({
-        llmModelId: selectedModel,
+        llmModelId: selectedModel
+          ? toBackendModelId(selectedModel)
+          : selectedModel,
         llmApiKey,
         llmBaseUrl,
-        llmTemperature: isLocalCompat ? localLlm.temperature : undefined,
-        llmMaxTokens: isLocalCompat ? localLlm.maxTokens : undefined,
-        llmCustomSystemPrompt: isLocalCompat
-          ? localLlm.customSystemPrompt
-          : undefined,
+        llmTemperature: presetCfg2?.temperature ?? undefined,
+        llmMaxTokens: presetCfg2?.maxTokens ?? undefined,
+        llmCustomSystemPrompt: presetCfg2?.customSystemPrompt || undefined,
         language,
         shaderEffect: renderEffect,
         shaderStroke: renderStroke,
@@ -719,27 +748,30 @@ export const useLlmMutations = () => {
     queryClient.setQueryData(readyKey, false)
     const models = getCachedLlmModels(queryClient)
     const modelInfo = models.find((m) => m.id === selectedModel)
-    const apiKey =
-      modelInfo && modelInfo.source !== 'local'
+    const presetCfg = selectedModel
+      ? getPresetConfigForModel(selectedModel)
+      : undefined
+    const apiKey = presetCfg
+      ? presetCfg.apiKey || undefined
+      : modelInfo && modelInfo.source !== 'local'
         ? usePreferencesStore.getState().apiKeys[modelInfo.source]
         : undefined
     const baseUrl =
       modelInfo?.source === 'openai-compatible'
         ? getBaseUrlForModel(selectedModel)
         : undefined
-    const localLlmConfig = usePreferencesStore.getState().localLlm
-    const isLocalCompatible = modelInfo?.source === 'openai-compatible'
+    const backendModelId = toBackendModelId(selectedModel)
     await api.llmLoad(
-      selectedModel,
+      backendModelId,
       apiKey,
       baseUrl,
-      isLocalCompatible ? localLlmConfig.temperature : undefined,
-      isLocalCompatible ? localLlmConfig.maxTokens : undefined,
-      isLocalCompatible ? localLlmConfig.customSystemPrompt : undefined,
+      presetCfg?.temperature ?? undefined,
+      presetCfg?.maxTokens ?? undefined,
+      presetCfg?.customSystemPrompt || undefined,
     )
     queryClient.setQueryData(
       readyKey,
-      await api.llmReady(selectedModel).catch(() => false),
+      await api.llmReady(backendModelId).catch(() => false),
     )
     await setProgress(100, ProgressBarStatus.Paused)
   }, [queryClient, setProgress])

--- a/ui/lib/stores/preferencesStore.ts
+++ b/ui/lib/stores/preferencesStore.ts
@@ -3,16 +3,37 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 
-export type LocalLlmConfig = {
-  preset: 'ollama' | 'lmstudio' | 'custom'
+export type LocalLlmPreset = 'ollama' | 'lmstudio' | 'preset1' | 'preset2'
+
+export type LocalLlmPresetConfig = {
   baseUrl: string
   apiKey: string
   modelName: string
   temperature: number | null
   maxTokens: number | null
   customSystemPrompt: string
+}
+
+export type LocalLlmConfig = {
+  activePreset: LocalLlmPreset
+  presets: Record<LocalLlmPreset, LocalLlmPresetConfig>
   targetLanguage: string
 }
+
+/** Convenience: get the config for the currently active preset. */
+export const getActivePresetConfig = (llm: LocalLlmConfig) =>
+  llm.presets[llm.activePreset]
+
+/** Get config for a specific preset. */
+export const getPresetConfig = (llm: LocalLlmConfig, preset: LocalLlmPreset) =>
+  llm.presets[preset]
+
+export const ALL_PRESETS: LocalLlmPreset[] = [
+  'ollama',
+  'lmstudio',
+  'preset1',
+  'preset2',
+]
 
 type PreferencesState = {
   brushConfig: {
@@ -30,18 +51,28 @@ type PreferencesState = {
   setProviderModelName: (provider: string, name: string) => void
   openAiCompatibleConfigVersion: number
   localLlm: LocalLlmConfig
-  setLocalLlm: (config: Partial<LocalLlmConfig>) => void
+  setLocalLlm: (config: Partial<LocalLlmPresetConfig>) => void
+  setActivePreset: (preset: LocalLlmPreset) => void
   resetPreferences: () => void
 }
 
-const initialLocalLlm: LocalLlmConfig = {
-  preset: 'ollama',
-  baseUrl: 'http://localhost:11434/v1',
+const defaultPresetConfig = (baseUrl: string): LocalLlmPresetConfig => ({
+  baseUrl,
   apiKey: '',
   modelName: '',
   temperature: null,
   maxTokens: null,
   customSystemPrompt: '',
+})
+
+const initialLocalLlm: LocalLlmConfig = {
+  activePreset: 'ollama',
+  presets: {
+    ollama: defaultPresetConfig('http://localhost:11434/v1'),
+    lmstudio: defaultPresetConfig('http://127.0.0.1:1234/v1'),
+    preset1: defaultPresetConfig(''),
+    preset2: defaultPresetConfig(''),
+  },
   targetLanguage: 'en-US',
 }
 
@@ -100,9 +131,24 @@ export const usePreferencesStore = create<PreferencesState>()(
               ? state.openAiCompatibleConfigVersion + 1
               : state.openAiCompatibleConfigVersion,
         })),
+      setActivePreset: (preset) =>
+        set((state) => ({
+          localLlm: { ...state.localLlm, activePreset: preset },
+          openAiCompatibleConfigVersion:
+            state.openAiCompatibleConfigVersion + 1,
+        })),
       setLocalLlm: (config) =>
         set((state) => ({
-          localLlm: { ...state.localLlm, ...config },
+          localLlm: {
+            ...state.localLlm,
+            presets: {
+              ...state.localLlm.presets,
+              [state.localLlm.activePreset]: {
+                ...state.localLlm.presets[state.localLlm.activePreset],
+                ...config,
+              },
+            },
+          },
           openAiCompatibleConfigVersion:
             state.openAiCompatibleConfigVersion + 1,
         })),
@@ -110,6 +156,60 @@ export const usePreferencesStore = create<PreferencesState>()(
     }),
     {
       name: 'koharu-config',
+      version: 1,
+      migrate: (persisted: any, version: number) => {
+        if (
+          version === 0 &&
+          persisted?.localLlm &&
+          !persisted.localLlm.presets
+        ) {
+          // Migrate flat LocalLlmConfig → per-preset format
+          const old = persisted.localLlm as {
+            preset?: string
+            baseUrl?: string
+            apiKey?: string
+            modelName?: string
+            temperature?: number | null
+            maxTokens?: number | null
+            customSystemPrompt?: string
+            targetLanguage?: string
+          }
+          const oldPreset =
+            old.preset === 'lmstudio'
+              ? 'lmstudio'
+              : old.preset === 'custom'
+                ? 'preset1'
+                : 'ollama'
+          const migratedConfig: LocalLlmPresetConfig = {
+            baseUrl: old.baseUrl ?? '',
+            apiKey: old.apiKey ?? '',
+            modelName: old.modelName ?? '',
+            temperature: old.temperature ?? null,
+            maxTokens: old.maxTokens ?? null,
+            customSystemPrompt: old.customSystemPrompt ?? '',
+          }
+          persisted.localLlm = {
+            activePreset: oldPreset,
+            presets: {
+              ollama:
+                oldPreset === 'ollama'
+                  ? migratedConfig
+                  : defaultPresetConfig('http://localhost:11434/v1'),
+              lmstudio:
+                oldPreset === 'lmstudio'
+                  ? migratedConfig
+                  : defaultPresetConfig('http://127.0.0.1:1234/v1'),
+              preset1:
+                oldPreset === 'preset1'
+                  ? migratedConfig
+                  : defaultPresetConfig(''),
+              preset2: defaultPresetConfig(''),
+            },
+            targetLanguage: old.targetLanguage ?? 'en-US',
+          } satisfies LocalLlmConfig
+        }
+        return persisted
+      },
       partialize: (state) => ({
         brushConfig: state.brushConfig,
         fontFamily: state.fontFamily,


### PR DESCRIPTION
## Summary
Frontend LLM settings restructured, split from #275:

- **Multi-preset support**: 4 independent presets (Ollama, LM Studio, Preset 1, Preset 2) each with their own baseUrl, modelName, apiKey, temperature, maxTokens, and system prompt
- **Settings page rewrite**: Flat config replaced with preset tab UI
- **Model ID format**: `openai-compatible:preset:modelName` for clean preset resolution
- **Automatic migration**: Old flat config (version 0) converts to per-preset format (version 1)
- **LLM status popover**: Preset-aware badge colors (emerald for Ollama/LM Studio, teal for custom presets)

## Changed files
- `ui/lib/stores/preferencesStore.ts` — new preset types, migration, per-preset accessors
- `ui/lib/query/hooks.ts` — model ID parsing, preset-aware model list
- `ui/lib/query/mutations.ts` — preset config resolution for process/translate/load
- `ui/components/canvas/CanvasToolbar.tsx` — LLM popover badge and info card
- `ui/app/(app)/settings/page.tsx` — preset tabs UI

## Test plan
- [ ] Open settings, verify 4 LLM preset tabs work
- [ ] Configure Ollama preset, verify model loads correctly
- [ ] Switch presets, verify each has independent config
- [ ] Process an image, verify correct preset config is sent to backend
- [ ] Verify old config migrates correctly on first load