### PR TITLE
feat(i18n): add translation keys for new canvas tools

### DIFF
--- a/ui/public/locales/en-US/translation.json
+++ b/ui/public/locales/en-US/translation.json
@@ -69,11 +69,15 @@
     "brush": "Brush Layer",
     "inpainted": "Inpainted",
     "mask": "Segmentation Mask",
-    "base": "Original Image"
+    "base": "Original Image",
+    "originalImage": "Original Image",
+    "on": "ON"
   },
   "processing": {
     "detect": "Detect",
     "detectTooltip": "Run text detection on current page",
+    "detectSensitive": "Detect+",
+    "detectSensitiveTooltip": "Sensitive detection — lower thresholds, catches more text (SFX, small text, complex backgrounds)",
     "ocr": "OCR",
     "ocrTooltip": "Recognize text for detected regions",
     "render": "Render"
@@ -153,6 +157,8 @@
     }
   },
   "render": {
+    "fontSizeLabel": "Size",
+    "fontSizeTooltip": "Font Size",
     "effectLabel": "Text effect",
     "alignLabel": "Align",
     "alignLeft": "Align left",
@@ -173,6 +179,7 @@
   "textBlocks": {
     "emptyPrompt": "Open an image to see text blocks.",
     "title": "Text Blocks ({{count}})",
+    "selected": "{{count}} selected",
     "none": "No text blocks yet. Run detection to populate the list.",
     "emptySummary": "<empty>",
     "ocrLabel": "OCR text",
@@ -201,7 +208,8 @@
     "block": "Block",
     "brush": "Brush",
     "repairBrush": "Repair brush",
-    "eraser": "Eraser"
+    "eraser": "Eraser",
+    "magicEraser": "Magic Eraser"
   },
   "download": {
     "title": "Downloading"
@@ -249,11 +257,13 @@
     "apiKeysDescription": "Manage your API keys for different providers. Your keys are stored securely on your device keychain and are never shared with anyone.",
     "freeTier": "Free Tier",
     "localLlm": "Local LLM",
+    "localLlmTitle": "Local LLM & OpenAI Compatible Providers",
     "localLlmDescription": "Connect to a local LLM server (Ollama, LM Studio, or any OpenAI-compatible endpoint) for translation.",
     "localLlmPreset": "Provider",
     "localLlmPresetOllama": "Ollama",
     "localLlmPresetLmStudio": "LM Studio",
-    "localLlmPresetCustom": "Custom",
+    "localLlmPresetPreset1": "Preset 1",
+    "localLlmPresetPreset2": "Preset 2",
     "localLlmBaseUrl": "Base URL",
     "localLlmApiKey": "API Key (optional)",
     "localLlmModelName": "Model name",

--- a/ui/public/locales/es-ES/translation.json
+++ b/ui/public/locales/es-ES/translation.json
@@ -69,11 +69,15 @@
     "brush": "Capa de pincel",
     "inpainted": "Rellenado",
     "mask": "Máscara de segmentación",
-    "base": "Imagen original"
+    "base": "Imagen original",
+    "originalImage": "Imagen original",
+    "on": "SÍ"
   },
   "processing": {
     "detect": "Detectar",
     "detectTooltip": "Ejecutar detección de texto en la página actual",
+    "detectSensitive": "Detectar+",
+    "detectSensitiveTooltip": "Detección sensible — umbrales más bajos, captura más texto (SFX, texto pequeño, fondos complejos)",
     "ocr": "OCR",
     "ocrTooltip": "Reconocer texto en las regiones detectadas",
     "render": "Renderizar"
@@ -153,6 +157,8 @@
     }
   },
   "render": {
+    "fontSizeLabel": "Tamaño",
+    "fontSizeTooltip": "Tamaño de fuente",
     "effectLabel": "Efecto de texto",
     "alignLabel": "Alineación",
     "alignLeft": "Alinear a la izquierda",
@@ -173,6 +179,7 @@
   "textBlocks": {
     "emptyPrompt": "Abre una imagen para ver los bloques de texto.",
     "title": "Bloques de texto ({{count}})",
+    "selected": "{{count}} seleccionados",
     "none": "Aún no hay bloques de texto. Ejecuta la detección para llenar la lista.",
     "emptySummary": "<vacío>",
     "ocrLabel": "Texto OCR",
@@ -201,7 +208,8 @@
     "block": "Bloque",
     "brush": "Pincel",
     "repairBrush": "Pincel de reparación",
-    "eraser": "Borrador"
+    "eraser": "Borrador",
+    "magicEraser": "Borrador mágico"
   },
   "download": {
     "title": "Descargando"
@@ -249,11 +257,13 @@
     "apiKeysDescription": "Gestiona tus claves API para diferentes proveedores. Tus claves se almacenan de forma segura en el llavero de tu dispositivo y nunca se comparten con nadie.",
     "freeTier": "Nivel gratuito",
     "localLlm": "LLM local",
+    "localLlmTitle": "LLM local y proveedores compatibles con OpenAI",
     "localLlmDescription": "Conector a un servidor LLM local (Ollama, LM Studio o cualquier endpoint compatible con OpenAI) para traducir.",
     "localLlmPreset": "Proveedor",
     "localLlmPresetOllama": "Ollama",
     "localLlmPresetLmStudio": "LM Studio",
-    "localLlmPresetCustom": "Personalizado",
+    "localLlmPresetPreset1": "Preset 1",
+    "localLlmPresetPreset2": "Preset 2",
     "localLlmBaseUrl": "Base URL",
     "localLlmApiKey": "Clave API (opcional)",
     "localLlmModelName": "Nombre del modelo",

--- a/ui/public/locales/ja-JP/translation.json
+++ b/ui/public/locales/ja-JP/translation.json
@@ -69,11 +69,15 @@
     "brush": "ブラシレイヤー",
     "inpainted": "インペイント",
     "mask": "セグメンテーションマスク",
-    "base": "元画像"
+    "base": "元画像",
+    "originalImage": "元画像",
+    "on": "ON"
   },
   "processing": {
     "detect": "検出",
     "detectTooltip": "現在のページでテキスト検出を実行",
+    "detectSensitive": "検出+",
+    "detectSensitiveTooltip": "高感度検出 — 低閾値でより多くのテキストを検出（効果音、小さい文字、複雑な背景）",
     "ocr": "OCR",
     "ocrTooltip": "検出された領域のテキストを認識",
     "render": "レンダー"
@@ -153,6 +157,8 @@
     }
   },
   "render": {
+    "fontSizeLabel": "サイズ",
+    "fontSizeTooltip": "フォントサイズ",
     "effectLabel": "文字効果",
     "alignLabel": "配置",
     "alignLeft": "左揃え",
@@ -173,6 +179,7 @@
   "textBlocks": {
     "emptyPrompt": "画像を開くとテキストブロックが表示されます。",
     "title": "テキストブロック（{{count}}）",
+    "selected": "{{count}} 件選択",
     "none": "まだテキストブロックがありません。検出を実行してください。",
     "emptySummary": "<空>",
     "ocrLabel": "OCR テキスト",
@@ -201,7 +208,8 @@
     "block": "ブロック",
     "brush": "ブラシ",
     "repairBrush": "リペアブラシ",
-    "eraser": "消しゴム"
+    "eraser": "消しゴム",
+    "magicEraser": "マジック消しゴム"
   },
   "download": {
     "title": "ダウンロード中"
@@ -249,11 +257,13 @@
     "apiKeysDescription": "異なるプロバイダーの API キーを管理します。キーはデバイスのキーチェーンに安全に保存され、他人と共有されることはありません。",
     "freeTier": "無料プラン",
     "localLlm": "ローカル LLM",
+    "localLlmTitle": "ローカル LLM & OpenAI 互換プロバイダー",
     "localLlmDescription": "ローカル LLM サーバー（Ollama、LM Studio、その他 OpenAI 互換エンドポイント）に接続して翻訳を行います。",
     "localLlmPreset": "プロバイダー",
     "localLlmPresetOllama": "Ollama",
     "localLlmPresetLmStudio": "LM Studio",
-    "localLlmPresetCustom": "カスタム",
+    "localLlmPresetPreset1": "プリセット 1",
+    "localLlmPresetPreset2": "プリセット 2",
     "localLlmBaseUrl": "Base URL",
     "localLlmApiKey": "API キー（任意）",
     "localLlmModelName": "モデル名",

--- a/ui/public/locales/ru-RU/translation.json
+++ b/ui/public/locales/ru-RU/translation.json
@@ -69,11 +69,15 @@
     "brush": "Слой кисти",
     "inpainted": "Инпейнтинг",
     "mask": "Маска сегментации",
-    "base": "Исходное изображение"
+    "base": "Исходное изображение",
+    "originalImage": "Исходное изображение",
+    "on": "ВКЛ"
   },
   "processing": {
     "detect": "Детекция",
     "detectTooltip": "Запустить детекцию текста на текущей странице",
+    "detectSensitive": "Детекция+",
+    "detectSensitiveTooltip": "Чувствительная детекция — низкие пороги, находит больше текста (SFX, мелкий текст, сложные фоны)",
     "ocr": "OCR",
     "ocrTooltip": "Распознать текст в обнаруженных областях",
     "render": "Рендер"
@@ -153,6 +157,8 @@
     }
   },
   "render": {
+    "fontSizeLabel": "Размер",
+    "fontSizeTooltip": "Размер шрифта",
     "effectLabel": "Эффект текста",
     "alignLabel": "Выравнивание",
     "alignLeft": "По левому краю",
@@ -173,6 +179,7 @@
   "textBlocks": {
     "emptyPrompt": "Откройте изображение, чтобы увидеть текстовые блоки.",
     "title": "Текстовые блоки ({{count}})",
+    "selected": "{{count}} выбрано",
     "none": "Текстовых блоков пока нет. Запустите обнаружение, чтобы заполнить список.",
     "emptySummary": "<пусто>",
     "ocrLabel": "Текст OCR",
@@ -201,7 +208,8 @@
     "block": "Блок",
     "brush": "Кисть",
     "repairBrush": "Кисть восстановления",
-    "eraser": "Ластик"
+    "eraser": "Ластик",
+    "magicEraser": "Волшебный ластик"
   },
   "download": {
     "title": "Загрузка"
@@ -249,11 +257,13 @@
     "apiKeysDescription": "Управляйте своими API ключами для различных провайдеров. Ваши ключи надежно хранятся в связке ключей вашего устройства и никогда не передаются другим лицам.",
     "freeTier": "Бесплатный уровень",
     "localLlm": "Локальная LLM",
+    "localLlmTitle": "Локальная LLM и OpenAI-совместимые провайдеры",
     "localLlmDescription": "Подключитесь к локальному серверу LLM (Ollama, LM Studio или любой OpenAI-совместимый эндпоинт) для перевода.",
     "localLlmPreset": "Провайдер",
     "localLlmPresetOllama": "Ollama",
     "localLlmPresetLmStudio": "LM Studio",
-    "localLlmPresetCustom": "Другой",
+    "localLlmPresetPreset1": "Пресет 1",
+    "localLlmPresetPreset2": "Пресет 2",
     "localLlmBaseUrl": "Base URL",
     "localLlmApiKey": "API ключ (необязательно)",
     "localLlmModelName": "Имя модели",

--- a/ui/public/locales/zh-CN/translation.json
+++ b/ui/public/locales/zh-CN/translation.json
@@ -69,11 +69,15 @@
     "brush": "笔刷图层",
     "inpainted": "修补图像",
     "mask": "分割遮罩",
-    "base": "原始图像"
+    "base": "原始图像",
+    "originalImage": "原始图像",
+    "on": "开"
   },
   "processing": {
     "detect": "检测",
     "detectTooltip": "对当前页面运行文本检测",
+    "detectSensitive": "检测+",
+    "detectSensitiveTooltip": "敏感检测 — 更低阈值，捕获更多文本（音效、小字、复杂背景）",
     "ocr": "识别",
     "ocrTooltip": "识别已检测区域中的文本",
     "render": "渲染"
@@ -153,6 +157,8 @@
     }
   },
   "render": {
+    "fontSizeLabel": "大小",
+    "fontSizeTooltip": "字体大小",
     "effectLabel": "文字效果",
     "alignLabel": "对齐",
     "alignLeft": "左对齐",
@@ -173,6 +179,7 @@
   "textBlocks": {
     "emptyPrompt": "打开图像以查看文本块。",
     "title": "文本块（{{count}}）",
+    "selected": "已选 {{count}} 个",
     "none": "尚无文本块。运行检测以填充列表。",
     "emptySummary": "<空>",
     "ocrLabel": "OCR 文本",
@@ -201,7 +208,8 @@
     "block": "框选",
     "brush": "画笔",
     "repairBrush": "修复笔",
-    "eraser": "橡皮擦"
+    "eraser": "橡皮擦",
+    "magicEraser": "魔术橡皮擦"
   },
   "download": {
     "title": "下载中"
@@ -249,11 +257,13 @@
     "apiKeysDescription": "管理您在不同提供商的 API 密钥。您的密钥会安全地存储在设备的密钥链中，绝不会与他人共享。",
     "freeTier": "免费等级",
     "localLlm": "本地 LLM",
+    "localLlmTitle": "本地 LLM 和 OpenAI 兼容提供商",
     "localLlmDescription": "连接本地 LLM 服务器（Ollama、LM Studio 或任何 OpenAI 兼容接口）进行翻译。",
     "localLlmPreset": "提供商",
     "localLlmPresetOllama": "Ollama",
     "localLlmPresetLmStudio": "LM Studio",
-    "localLlmPresetCustom": "自定义",
+    "localLlmPresetPreset1": "预设 1",
+    "localLlmPresetPreset2": "预设 2",
     "localLlmBaseUrl": "Base URL",
     "localLlmApiKey": "API 密钥（可选）",
     "localLlmModelName": "模型名称",

--- a/ui/public/locales/zh-TW/translation.json
+++ b/ui/public/locales/zh-TW/translation.json
@@ -69,11 +69,15 @@
     "brush": "筆刷圖層",
     "inpainted": "修補影像",
     "mask": "分割遮罩",
-    "base": "原始影像"
+    "base": "原始影像",
+    "originalImage": "原始影像",
+    "on": "開"
   },
   "processing": {
     "detect": "偵測",
     "detectTooltip": "在目前頁面執行文字偵測",
+    "detectSensitive": "偵測+",
+    "detectSensitiveTooltip": "敏感偵測 — 更低閾值，擷取更多文字（音效、小字、複雜背景）",
     "ocr": "辨識",
     "ocrTooltip": "辨識已偵測區域中的文字",
     "render": "渲染"
@@ -153,6 +157,8 @@
     }
   },
   "render": {
+    "fontSizeLabel": "大小",
+    "fontSizeTooltip": "字體大小",
     "effectLabel": "文字效果",
     "alignLabel": "對齊",
     "alignLeft": "靠左對齊",
@@ -173,6 +179,7 @@
   "textBlocks": {
     "emptyPrompt": "開啟影像以查看文字區塊。",
     "title": "文字區塊（{{count}}）",
+    "selected": "已選 {{count}} 個",
     "none": "尚無文字區塊。請執行偵測以產生列表。",
     "emptySummary": "<空>",
     "ocrLabel": "OCR 文字",
@@ -201,7 +208,8 @@
     "block": "框選",
     "brush": "筆刷",
     "repairBrush": "修復筆",
-    "eraser": "橡皮擦"
+    "eraser": "橡皮擦",
+    "magicEraser": "魔術橡皮擦"
   },
   "download": {
     "title": "下載中"
@@ -249,11 +257,13 @@
     "apiKeysDescription": "管理您在不同提供商的 API 密鑰。您的密鑰會安全地存儲在設備的密鑰鏈中，絕不會與他人共享。",
     "freeTier": "免費等級",
     "localLlm": "本機 LLM",
+    "localLlmTitle": "本機 LLM 與 OpenAI 相容提供者",
     "localLlmDescription": "連線至本機 LLM 伺服器（Ollama、LM Studio 或任何 OpenAI 相容端點）進行翻譯。",
     "localLlmPreset": "提供者",
     "localLlmPresetOllama": "Ollama",
     "localLlmPresetLmStudio": "LM Studio",
-    "localLlmPresetCustom": "自訂",
+    "localLlmPresetPreset1": "預設 1",
+    "localLlmPresetPreset2": "預設 2",
     "localLlmBaseUrl": "Base URL",
     "localLlmApiKey": "API 密鑰（選填）",
     "localLlmModelName": "模型名稱",


### PR DESCRIPTION
## Summary
Translation updates for all 6 locales, split from #275.

New keys for: magic eraser, detect+, original image toggle, font size controls, multi-select operations, and tool keyboard shortcuts.

**Locales updated:** en-US, es-ES, ja-JP, ru-RU, zh-CN, zh-TW

## Test plan
- [ ] Verify new keys render correctly in each locale
- [ ] No missing translation warnings in console