### PR TITLE
ci: cache bun packages and Next.js build output

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,17 +23,7 @@ jobs:
           method: 'network'
           sub-packages: '["nvcc", "cudart", "crt", "thrust", "nvvm", "cublas", "cublas_dev", "cufft", "cufft_dev", "curand", "curand_dev", "nvrtc", "nvrtc_dev"]'
       - uses: ilammy/msvc-dev-cmd@v1
-      - uses: actions/cache@v5
-        with:
-          path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
       - run: bun install
-      - uses: actions/cache@v5
-        with:
-          path: ${{ github.workspace }}/ui/.next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/bun.lock') }}-${{ hashFiles('ui/**/*.js', 'ui/**/*.jsx', 'ui/**/*.ts', 'ui/**/*.tsx') }}
-          restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/bun.lock') }}-
       - working-directory: ./ui
         run: bun run build
       - run: cargo publish --workspace --no-verify --token ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,20 +60,8 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
         if: matrix.platform == 'windows-latest'
 
-      - uses: actions/cache@v5
-        with:
-          path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
-
       - name: Install dependencies
         run: bun install
-
-      - uses: actions/cache@v5
-        with:
-          path: ${{ github.workspace }}/ui/.next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/bun.lock') }}-${{ hashFiles('ui/**/*.js', 'ui/**/*.jsx', 'ui/**/*.ts', 'ui/**/*.tsx') }}
-          restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/bun.lock') }}-
 
       - name: Generate release changelog
         id: release_notes


### PR DESCRIPTION
## Summary
- Add `actions/cache@v5` for bun package cache (`~/.bun/install/cache`) to speed up `bun install`
- Add `actions/cache@v5` for Next.js build cache (`ui/.next/cache`) to eliminate "No build cache found" warning and speed up frontend compilation

Applied to all workflows that build the frontend: `build.yml`, `release.yaml`, `publish.yml`.

## References
- https://github.com/actions/cache/blob/main/examples.md#bun
- https://nextjs.org/docs/messages/no-cache
