### PR TITLE
fix: load CJK fonts at runtime to fix Turbopack build failures

### DIFF
--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -137,8 +137,8 @@
   body {
     @apply bg-background text-foreground select-none;
     font-family:
-      var(--font-inter), var(--font-noto-sc), var(--font-noto-tc),
-      var(--font-noto-jp), ui-sans-serif, system-ui, sans-serif;
+      var(--font-inter), 'Noto Sans SC', 'Noto Sans TC', 'Noto Sans JP',
+      ui-sans-serif, system-ui, sans-serif;
   }
   input,
   textarea {

--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -1,31 +1,11 @@
 import type { Metadata } from 'next'
-import {
-  Inter,
-  Noto_Sans_JP,
-  Noto_Sans_SC,
-  Noto_Sans_TC,
-} from 'next/font/google'
+import { Inter } from 'next/font/google'
 import './globals.css'
 import Providers from '@/app/providers'
 
 const inter = Inter({
   subsets: ['latin'],
   variable: '--font-inter',
-})
-
-const notoSansJP = Noto_Sans_JP({
-  subsets: ['latin'],
-  variable: '--font-noto-jp',
-})
-
-const notoSansSC = Noto_Sans_SC({
-  subsets: ['latin'],
-  variable: '--font-noto-sc',
-})
-
-const notoSansTC = Noto_Sans_TC({
-  subsets: ['latin'],
-  variable: '--font-noto-tc',
 })
 
 export const metadata: Metadata = {
@@ -39,8 +19,16 @@ function RootLayout({
 }>) {
   return (
     <html lang='en-US'>
+      <head>
+        {/* CJK fonts loaded from Google Fonts to avoid Turbopack bundling failures.
+            In offline/Tauri builds, these fonts fall back to system CJK fonts. */}
+        <link
+          rel='stylesheet'
+          href='https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@100..900&family=Noto+Sans+SC:wght@100..900&family=Noto+Sans+TC:wght@100..900&display=swap'
+        />
+      </head>
       <body
-        className={`${inter.variable} ${notoSansSC.variable} ${notoSansTC.variable} ${notoSansJP.variable} antialiased`}
+        className={`${inter.variable} antialiased`}
         suppressHydrationWarning
       >
         <Providers>{children}</Providers>


### PR DESCRIPTION
## Summary
- Switch Noto Sans CJK (SC/TC/JP) from `next/font` bundling to Google Fonts `<link>` stylesheet
- Turbopack fails to bundle large CJK font files during development, causing missing glyphs
- Runtime loading avoids this while falling back to system CJK fonts when offline

## Test plan
- [ ] `bun dev` / `next dev` starts without font bundling errors
- [ ] CJK characters render correctly (Japanese, Simplified Chinese, Traditional Chinese)
- [ ] App works in Tauri offline mode with system CJK fonts as fallback