### PR TITLE
fix: canvas performance, block merge, multi-select, undo reliability

### DIFF
--- a/ui/components/canvas/TextBlockAnnotations.tsx
+++ b/ui/components/canvas/TextBlockAnnotations.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Rnd, type RndResizeCallback, type RndDragCallback } from 'react-rnd'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { useEditorUiStore } from '@/lib/stores/editorUiStore'
@@ -9,18 +9,24 @@ import { useTextBlocks } from '@/hooks/useTextBlocks'
 
 type TextBlockAnnotationsProps = {
   selectedIndex?: number
+  selectedIndices?: number[]
   onSelect: (index?: number) => void
+  onToggleSelect?: (index: number) => void
   style?: React.CSSProperties
 }
 
 export function TextBlockAnnotations({
   selectedIndex,
+  selectedIndices = [],
   onSelect,
+  onToggleSelect,
   style,
 }: TextBlockAnnotationsProps) {
-  const { textBlocks, replaceBlock, removeBlock } = useTextBlocks()
+  const { textBlocks, replaceBlock, removeBlock, commitDragUndo } =
+    useTextBlocks()
   const mode = useEditorUiStore((state) => state.mode)
   const interactive = mode === 'select' || mode === 'block'
+  const selectedIndicesSet = useMemo(() => new Set(selectedIndices), [selectedIndices])
 
   useHotkeys(
     'backspace,delete',
@@ -52,13 +58,16 @@ export function TextBlockAnnotations({
     >
       {textBlocks.map((block, index) => (
         <TextBlockAnnotation
-          key={`${block.x}-${block.y}-${index}`}
+          key={block.id ?? index}
           block={block}
           index={index}
           selected={index === selectedIndex}
+          multiSelected={selectedIndicesSet.has(index)}
           onSelect={onSelect}
+          onToggleSelect={onToggleSelect}
           interactive={interactive}
           onUpdate={(updates) => void replaceBlock(index, updates)}
+          onDragEnd={commitDragUndo}
         />
       ))}
     </div>
@@ -69,21 +78,28 @@ type TextBlockAnnotationProps = {
   block: TextBlock
   index: number
   selected: boolean
+  multiSelected: boolean
   interactive: boolean
   onSelect: (index: number) => void
+  onToggleSelect?: (index: number) => void
   onUpdate: (updates: Partial<TextBlock>) => void
+  onDragEnd: () => void
 }
 
 function TextBlockAnnotation({
   block,
   index,
   selected,
+  multiSelected,
   interactive,
   onSelect,
+  onToggleSelect,
   onUpdate,
+  onDragEnd,
 }: TextBlockAnnotationProps) {
   const scale = useEditorUiStore((state) => state.scale)
   const scaleRatio = scale / 100
+  const draggingRef = useRef(false)
 
   const scaledSize = {
     width: Math.max(0, block.width * scaleRatio),
@@ -98,7 +114,9 @@ function TextBlockAnnotation({
   const [size, setSize] = useState(scaledSize)
   const [position, setPosition] = useState(scaledPosition)
 
+  // Sync from props, but NOT while the user is actively dragging.
   useEffect(() => {
+    if (draggingRef.current) return
     setSize(scaledSize)
     setPosition(scaledPosition)
   }, [scaledPosition.x, scaledPosition.y, scaledSize.width, scaledSize.height])
@@ -110,12 +128,15 @@ function TextBlockAnnotation({
 
   const handleDragStop: RndDragCallback = (_, data) => {
     if (!interactive) return
+    draggingRef.current = false
     const nextPosition = { x: data.x, y: data.y }
     setPosition(nextPosition)
     onUpdate({
       x: Math.round(nextPosition.x / scaleRatio),
       y: Math.round(nextPosition.y / scaleRatio),
     })
+    // Commit the undo entry for the entire drag session
+    onDragEnd()
   }
 
   const handleResize: RndResizeCallback = (_, __, ref, ___, nextPosition) => {
@@ -127,8 +148,9 @@ function TextBlockAnnotation({
     setPosition(nextPosition)
   }
 
-  const handleResizeStop: RndResizeCallback = (_, __, ref, ___, position) => {
+  const handleResizeStop: RndResizeCallback = (_, __, ref, ___, pos) => {
     if (!interactive || !selected) return
+    draggingRef.current = false
     const widthPx = parseFloat(ref.style.width)
     const heightPx = parseFloat(ref.style.height)
     const nextSize = {
@@ -136,13 +158,31 @@ function TextBlockAnnotation({
       height: heightPx,
     }
     setSize(nextSize)
-    setPosition(position)
+    setPosition(pos)
     onUpdate({
-      x: Math.round(position.x / scaleRatio),
-      y: Math.round(position.y / scaleRatio),
+      x: Math.round(pos.x / scaleRatio),
+      y: Math.round(pos.y / scaleRatio),
       width: Math.max(4, Math.round(nextSize.width / scaleRatio)),
       height: Math.max(4, Math.round(nextSize.height / scaleRatio)),
     })
+  }
+
+  const handlePointerDown = (event: MouseEvent) => {
+    if (!interactive) return
+    event.stopPropagation()
+    // Right-click: preserve multi-selection when clicking a block that is
+    // already selected so the context menu can act on the whole selection.
+    if (event.button === 2) {
+      if (!selected && !multiSelected) {
+        onSelect(index)
+      }
+      return
+    }
+    if (event.ctrlKey || event.metaKey) {
+      onToggleSelect?.(index)
+    } else {
+      onSelect(index)
+    }
   }
 
   return (
@@ -167,43 +207,57 @@ function TextBlockAnnotation({
       }
       onDragStart={() => {
         if (!interactive) return
+        draggingRef.current = true
         onSelect(index)
       }}
       onDrag={handleDrag}
       onDragStop={handleDragStop}
       onResizeStart={() => {
         if (!interactive) return
+        draggingRef.current = true
         onSelect(index)
       }}
       onResize={handleResize}
       onResizeStop={handleResizeStop}
-      onMouseDown={(event) => {
-        if (!interactive) return
-        event.stopPropagation()
-        onSelect(index)
-      }}
-      onPointerDown={(event) => {
-        if (!interactive) return
-        event.stopPropagation()
-        onSelect(index)
-      }}
+      onMouseDown={handlePointerDown}
+      onPointerDown={handlePointerDown}
       style={{
-        zIndex: selected ? 20 : 10,
+        zIndex: selected ? 20 : multiSelected ? 15 : 10,
         pointerEvents: interactive ? 'auto' : 'none',
+        willChange: 'transform',
       }}
       className='absolute'
     >
-      <div className='relative h-full w-full select-none'>
+      <div
+        className='relative h-full w-full select-none'
+        onPointerDownCapture={(e) => {
+          // Intercept Ctrl+click BEFORE Rnd sees the event so that
+          // multi-selection works without interfering with Rnd's internal
+          // drag/select logic.
+          if (!interactive) return
+          if (e.ctrlKey || e.metaKey) {
+            e.stopPropagation()
+            e.preventDefault()
+            onToggleSelect?.(index)
+          }
+        }}
+      >
         <div
           className={`absolute inset-0 rounded ${
             selected
               ? 'border-primary bg-primary/15 border-[3px]'
-              : 'border-2 border-rose-400/60 bg-rose-400/5'
+              : multiSelected
+                ? 'border-[3px] border-sky-400 bg-sky-400/15'
+                : 'border-2 border-rose-400/60 bg-rose-400/5'
           }`}
         />
         <div
           className={`pointer-events-none absolute -top-1.5 -left-1.5 flex h-4 w-4 items-center justify-center rounded-full text-[9px] font-semibold text-white shadow ${
-            selected ? 'bg-primary' : 'bg-rose-400'
+            selected
+              ? 'bg-primary'
+              : multiSelected
+                ? 'bg-sky-400'
+                : 'bg-rose-400'
           }`}
         >
           {index + 1}

--- a/ui/components/canvas/Workspace.tsx
+++ b/ui/components/canvas/Workspace.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef } from 'react'
 import type React from 'react'
 import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area'
 import { useGesture } from '@use-gesture/react'
+import { useHotkeys } from 'react-hotkeys-hook'
 import {
   ContextMenu,
   ContextMenuContent,
@@ -30,6 +31,7 @@ import { useMaskDrawing } from '@/hooks/useMaskDrawing'
 import { useRenderBrushDrawing } from '@/hooks/useRenderBrushDrawing'
 import { useBrushLayerDisplay } from '@/hooks/useBrushLayerDisplay'
 import { useEditorUiStore } from '@/lib/stores/editorUiStore'
+import { useUndoStore } from '@/lib/stores/undoStore'
 import {
   resolvePinchMemoScaleRatio,
   resolvePinchNextScaleRatio,
@@ -51,15 +53,24 @@ export function Workspace() {
   const showTextBlocksOverlay = useEditorUiStore(
     (state) => state.showTextBlocksOverlay,
   )
+  const showOriginalOnly = useEditorUiStore((state) => state.showOriginalOnly)
+  const setShowOriginalOnly = useEditorUiStore(
+    (state) => state.setShowOriginalOnly,
+  )
   const mode = useEditorUiStore((state) => state.mode)
   const autoFitEnabled = useEditorUiStore((state) => state.autoFitEnabled)
+  const selectedBlockIndices = useEditorUiStore(
+    (state) => state.selectedBlockIndices,
+  )
   const {
     document: currentDocument,
     selectedBlockIndex,
     setSelectedBlockIndex,
+    toggleBlockSelection,
     clearSelection,
     appendBlock,
     removeBlock,
+    mergeBlocks,
   } = useTextBlocks()
   const viewportRef = useRef<HTMLDivElement | null>(null)
   const { setScale: applyScale } = useCanvasZoom()
@@ -75,8 +86,10 @@ export function Workspace() {
       void appendBlock(block)
     },
   })
+
   const maskPointerEnabled =
     mode === 'repairBrush' ||
+    mode === 'magicEraser' ||
     (mode === 'eraser' && (showSegmentationMask || !showBrushLayer))
   const brushPointerEnabled =
     mode === 'brush' ||
@@ -85,7 +98,7 @@ export function Workspace() {
     mode,
     currentDocument,
     pointerToDocument,
-    showMask: showSegmentationMask,
+    showMask: showSegmentationMask || mode === 'magicEraser',
     enabled: maskPointerEnabled,
   })
   const brushLayerDisplay = useBrushLayerDisplay({
@@ -103,6 +116,50 @@ export function Workspace() {
   const blockDraftBindings = bindBlockDraft()
   const maskBindings = maskDrawing.bind()
   const brushBindings = brushDrawing.bind()
+
+  // Undo / Redo hotkeys
+  const undo = useUndoStore((state) => state.undo)
+  const redo = useUndoStore((state) => state.redo)
+
+  useHotkeys(
+    'mod+z',
+    (e) => {
+      e.preventDefault()
+      undo()
+    },
+    { preventDefault: true },
+    [undo],
+  )
+
+  useHotkeys(
+    'mod+shift+z',
+    (e) => {
+      e.preventDefault()
+      redo()
+    },
+    { preventDefault: true },
+    [redo],
+  )
+
+  // Merge selected blocks (Ctrl+M)
+  useHotkeys(
+    'mod+m',
+    (e) => {
+      e.preventDefault()
+      const indices = useEditorUiStore.getState().selectedBlockIndices
+      if (indices.length >= 2) void mergeBlocks(indices)
+    },
+    { preventDefault: true, enableOnFormTags: false },
+    [mergeBlocks],
+  )
+
+  // Show Original hotkey (O)
+  useHotkeys(
+    'o',
+    () => setShowOriginalOnly(!showOriginalOnly),
+    { enableOnFormTags: false },
+    [showOriginalOnly, setShowOriginalOnly],
+  )
 
   useEffect(() => {
     if (currentDocument && autoFitEnabled) {
@@ -124,13 +181,14 @@ export function Workspace() {
   })
   const { t } = useTranslation()
 
-  // Listen for Tauri resize events
+  // Listen for Tauri resize events — register once, read state from store.
   useEffect(() => {
     let unlisten: (() => void) | undefined
 
     const setupListener = async () => {
       unlisten = await listen('tauri://resize', () => {
-        if (currentDocument && autoFitEnabled) {
+        const { autoFitEnabled, totalPages } = useEditorUiStore.getState()
+        if (totalPages > 0 && autoFitEnabled) {
           fitCanvasToViewport()
         }
       })
@@ -143,7 +201,7 @@ export function Workspace() {
         unlisten()
       }
     }
-  }, [currentDocument])
+  }, [])
 
   useGesture(
     {
@@ -209,7 +267,7 @@ export function Workspace() {
         enabled: true,
         pinchOnWheel: false,
         preventDefault: true,
-        scaleBounds: { min: 0.1, max: 1 },
+        scaleBounds: { min: 0.1, max: 4 },
         from: () => [useEditorUiStore.getState().scale / 100, 0],
       },
     },
@@ -228,7 +286,10 @@ export function Workspace() {
   }
 
   const isBrushMode =
-    mode === 'brush' || mode === 'repairBrush' || mode === 'eraser'
+    mode === 'brush' ||
+    mode === 'repairBrush' ||
+    mode === 'eraser' ||
+    mode === 'magicEraser'
   const canvasCursor = isBrushMode
     ? BRUSH_CURSOR
     : mode === 'block'
@@ -281,6 +342,7 @@ export function Workspace() {
                           dataKey={`${currentDocument.id}-base`}
                           transition={false}
                         />
+
                         <canvas
                           ref={maskDrawing.canvasRef}
                           data-testid='workspace-mask-canvas'
@@ -288,8 +350,15 @@ export function Workspace() {
                           style={{
                             width: '100%',
                             height: '100%',
-                            opacity: showSegmentationMask ? 0.8 : 0,
-                            pointerEvents: maskPointerEnabled ? 'auto' : 'none',
+                            opacity:
+                              !showOriginalOnly &&
+                              (showSegmentationMask || mode === 'magicEraser')
+                                ? 0.5
+                                : 0,
+                            pointerEvents:
+                              !showOriginalOnly && maskPointerEnabled
+                                ? 'auto'
+                                : 'none',
                             transition: 'opacity 120ms ease',
                           }}
                           {...maskBindings}
@@ -298,7 +367,7 @@ export function Workspace() {
                           <Image
                             data-testid='workspace-inpainted-image'
                             data={currentDocument.inpainted}
-                            visible={showInpaintedImage}
+                            visible={!showOriginalOnly && showInpaintedImage}
                             transition={false}
                           />
                         )}
@@ -309,7 +378,10 @@ export function Workspace() {
                           style={{
                             width: '100%',
                             height: '100%',
-                            opacity: brushLayerDisplay.visible ? 1 : 0,
+                            opacity:
+                              !showOriginalOnly && brushLayerDisplay.visible
+                                ? 1
+                                : 0,
                             pointerEvents: 'none',
                             zIndex: 10,
                             transition: 'opacity 120ms ease',
@@ -322,16 +394,18 @@ export function Workspace() {
                           style={{
                             width: '100%',
                             height: '100%',
-                            opacity: brushDrawing.visible ? 1 : 0,
-                            pointerEvents: brushPointerEnabled
-                              ? 'auto'
-                              : 'none',
+                            opacity:
+                              !showOriginalOnly && brushDrawing.visible ? 1 : 0,
+                            pointerEvents:
+                              !showOriginalOnly && brushPointerEnabled
+                                ? 'auto'
+                                : 'none',
                             zIndex: 20,
                             transition: 'opacity 120ms ease',
                           }}
                           {...brushBindings}
                         />
-                        {showTextBlocksOverlay && (
+                        {showTextBlocksOverlay && !showOriginalOnly && (
                           <TextBlockSpriteLayer
                             blocks={currentDocument?.textBlocks}
                             scale={scaleRatio}
@@ -339,21 +413,25 @@ export function Workspace() {
                             style={{ zIndex: 30 }}
                           />
                         )}
-                        {showTextBlocksOverlay && (
+                        {showTextBlocksOverlay && !showOriginalOnly && (
                           <TextBlockAnnotations
                             selectedIndex={selectedBlockIndex}
+                            selectedIndices={selectedBlockIndices}
                             onSelect={setSelectedBlockIndex}
+                            onToggleSelect={toggleBlockSelection}
                             style={{ zIndex: 30 }}
                           />
                         )}
-                        {currentDocument.rendered && showRenderedImage && (
-                          <Image
-                            data-testid='workspace-rendered-image'
-                            data={currentDocument.rendered}
-                            transition={false}
-                            style={{ zIndex: 40 }}
-                          />
-                        )}
+                        {currentDocument.rendered &&
+                          showRenderedImage &&
+                          !showOriginalOnly && (
+                            <Image
+                              data-testid='workspace-rendered-image'
+                              data={currentDocument.rendered}
+                              transition={false}
+                              style={{ zIndex: 40 }}
+                            />
+                          )}
                       </div>
                       {draftBlock && (
                         <div
@@ -370,6 +448,14 @@ export function Workspace() {
                   </div>
                 </ContextMenuTrigger>
                 <ContextMenuContent className='min-w-32'>
+                  <ContextMenuItem
+                    disabled={selectedBlockIndices.length < 2}
+                    onSelect={() =>
+                      void mergeBlocks(selectedBlockIndices)
+                    }
+                  >
+                    {t('workspace.mergeBlocks')}
+                  </ContextMenuItem>
                   <ContextMenuItem
                     disabled={contextMenuBlockIndex === undefined}
                     onSelect={handleDeleteBlock}

--- a/ui/components/panels/RenderControlsPanel.tsx
+++ b/ui/components/panels/RenderControlsPanel.tsx
@@ -13,11 +13,13 @@ import {
   SquareIcon,
 } from 'lucide-react'
 import { useTextBlocks } from '@/hooks/useTextBlocks'
+import { useUndoStore } from '@/lib/stores/undoStore'
 import {
   RenderEffect,
   RenderStroke,
   RgbaColor,
   TextAlign,
+  TextBlock,
   TextStyle,
 } from '@/types'
 import type { FontFaceInfo } from '@/lib/protocol'
@@ -62,6 +64,9 @@ const DEFAULT_STROKE_WIDTH = 1.6
 const MIN_STROKE_WIDTH = 0.2
 const MAX_STROKE_WIDTH = 24
 const STROKE_WIDTH_STEP = 0.1
+const DEFAULT_FONT_SIZE = 24
+const MIN_FONT_SIZE = 4
+const MAX_FONT_SIZE = 200
 const LATIN_ONLY_PATTERN =
   /^[\p{Script=Latin}\p{Script=Common}\p{Script=Inherited}]*$/u
 
@@ -72,6 +77,9 @@ const clampStrokeWidth = (value: number) =>
   Number(
     Math.max(MIN_STROKE_WIDTH, Math.min(MAX_STROKE_WIDTH, value)).toFixed(1),
   )
+
+const clampFontSize = (value: number) =>
+  Math.max(MIN_FONT_SIZE, Math.min(MAX_FONT_SIZE, Math.round(value)))
 
 const colorToHex = (color: RgbaColor) =>
   `#${color
@@ -183,11 +191,21 @@ export function RenderControlsPanel() {
   const renderStroke = useEditorUiStore((state) => state.renderStroke)
   const setRenderEffect = useEditorUiStore((state) => state.setRenderEffect)
   const setRenderStroke = useEditorUiStore((state) => state.setRenderStroke)
+  const selectedBlockIndices = useEditorUiStore(
+    (state) => state.selectedBlockIndices,
+  )
+  const pushUndo = useUndoStore((state) => state.push)
   const { updateTextBlocks } = useTextBlockMutations()
   const { data: availableFonts = [] } = useFontsQuery()
   const fontFamily = usePreferencesStore((state) => state.fontFamily)
   const setFontFamily = usePreferencesStore((state) => state.setFontFamily)
-  const { textBlocks, selectedBlockIndex, replaceBlock } = useTextBlocks()
+  const {
+    textBlocks,
+    selectedBlockIndex,
+    readCurrentBlocks,
+    replaceBlock,
+    replaceMultipleBlocks,
+  } = useTextBlocks()
   const { t } = useTranslation()
   const selectedBlock =
     selectedBlockIndex !== undefined
@@ -195,6 +213,7 @@ export function RenderControlsPanel() {
       : undefined
   const firstBlock = textBlocks[0]
   const hasBlocks = textBlocks.length > 0
+  const isMultiSelect = selectedBlockIndices.length > 1
   const fontCandidates = uniqueFontFaces(
     [
       ...availableFonts,
@@ -232,6 +251,11 @@ export function RenderControlsPanel() {
   const currentColorHex = colorToHex(currentColor)
   const currentStrokeColorHex = colorToHex(currentStroke.color)
   const currentStrokeWidth = currentStroke.widthPx ?? DEFAULT_STROKE_WIDTH
+  const currentFontSize =
+    selectedBlock?.style?.fontSize ??
+    selectedBlock?.detectedFontSizePx ??
+    selectedBlock?.fontPrediction?.font_size_px ??
+    DEFAULT_FONT_SIZE
   const fontLabel = t('render.fontLabel')
   const effectLabel = t('render.effectLabel')
   const strokeLabel = t('render.effectBorder')
@@ -241,14 +265,19 @@ export function RenderControlsPanel() {
   const currentTextAlign = resolveEffectiveTextAlign(
     selectedBlock ?? firstBlock,
   )
-  const scopeLabel =
-    selectedBlockIndex !== undefined
+  const scopeLabel = isMultiSelect
+    ? t('render.fontScopeMulti', {
+        count: selectedBlockIndices.length,
+        defaultValue: `${selectedBlockIndices.length} blocks`,
+      })
+    : selectedBlockIndex !== undefined
       ? t('render.fontScopeBlockIndex', {
           index: selectedBlockIndex + 1,
         })
       : t('render.fontScopeGlobal')
-  const scopeToneClass =
-    selectedBlockIndex !== undefined
+  const scopeToneClass = isMultiSelect
+    ? 'border-sky-400/20 bg-sky-400/10 text-sky-600'
+    : selectedBlockIndex !== undefined
       ? 'border-primary/20 bg-primary/10 text-primary'
       : 'border-border/60 bg-muted text-muted-foreground'
 
@@ -273,6 +302,41 @@ export function RenderControlsPanel() {
   })
 
   const applyStyleToSelected = (updates: Partial<TextStyle>) => {
+    // Multi-select: apply per-block computed styles with undo support
+    if (isMultiSelect) {
+      const indexSet = new Set(selectedBlockIndices)
+      const snapshots = new Map<number, TextBlock>()
+      selectedBlockIndices.forEach((i) => {
+        if (textBlocks[i]) snapshots.set(i, { ...textBlocks[i] })
+      })
+
+      const nextBlocks = textBlocks.map((block, idx) =>
+        indexSet.has(idx)
+          ? { ...block, style: buildStyle(block, block.style, updates) }
+          : block,
+      )
+      void updateTextBlocks(nextBlocks)
+
+      pushUndo({
+        type: 'replaceMultipleBlocks',
+        description: `Style ${selectedBlockIndices.length} blocks`,
+        undo: () => {
+          const blocks = readCurrentBlocks()
+          const restored = blocks.map((b, idx) => snapshots.get(idx) ?? b)
+          void updateTextBlocks(restored)
+        },
+        redo: () => {
+          const blocks = readCurrentBlocks()
+          const reapplied = blocks.map((block, idx) =>
+            indexSet.has(idx)
+              ? { ...block, style: buildStyle(block, block.style, updates) }
+              : block,
+          )
+          void updateTextBlocks(reapplied)
+        },
+      })
+      return true
+    }
     if (selectedBlockIndex === undefined) return false
     const nextStyle = buildStyle(selectedBlock, selectedBlock?.style, updates)
     void replaceBlock(selectedBlockIndex, { style: nextStyle })
@@ -311,6 +375,12 @@ export function RenderControlsPanel() {
       ...currentStroke,
       widthPx: clampStrokeWidth(value),
     })
+  }
+
+  const updateFontSize = (value: number) => {
+    const clamped = clampFontSize(value)
+    if (applyStyleToSelected({ fontSize: clamped })) return
+    // No global fontSize fallback — it requires a selected block
   }
 
   const effectItems: {
@@ -437,6 +507,69 @@ export function RenderControlsPanel() {
             </TooltipTrigger>
             <TooltipContent side='bottom' sideOffset={4}>
               {t('render.fontColorLabel')}
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      </div>
+
+      {/* Font Size */}
+      <div className='grid w-full min-w-0 grid-cols-[3.5rem_minmax(0,1fr)] items-center gap-1.5'>
+        <span className='text-muted-foreground text-[10px] font-medium tracking-wide uppercase'>
+          {t('render.fontSizeLabel')}
+        </span>
+
+        <div className='flex min-w-0 items-center gap-1'>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div className='border-input bg-background flex w-auto min-w-0 shrink-0 items-center rounded-md border shadow-xs'>
+                <Button
+                  type='button'
+                  variant='ghost'
+                  size='icon-sm'
+                  aria-label='Decrease font size'
+                  className='size-7 rounded-r-none border-r'
+                  disabled={!hasBlocks}
+                  onClick={() => updateFontSize(currentFontSize - 1)}
+                >
+                  <MinusIcon className='size-3' />
+                </Button>
+
+                <Input
+                  type='number'
+                  step='1'
+                  min={String(MIN_FONT_SIZE)}
+                  max={String(MAX_FONT_SIZE)}
+                  inputMode='numeric'
+                  className='h-7 w-14 min-w-0 [appearance:textfield] rounded-none border-0 px-1.5 text-center text-[11px] shadow-none focus-visible:ring-0 [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none'
+                  data-testid='render-font-size'
+                  disabled={!hasBlocks}
+                  value={
+                    Number.isFinite(currentFontSize)
+                      ? Math.round(currentFontSize)
+                      : DEFAULT_FONT_SIZE
+                  }
+                  onChange={(event) => {
+                    const parsed = Number.parseInt(event.target.value, 10)
+                    if (!Number.isFinite(parsed)) return
+                    updateFontSize(parsed)
+                  }}
+                />
+
+                <Button
+                  type='button'
+                  variant='ghost'
+                  size='icon-sm'
+                  aria-label='Increase font size'
+                  className='size-7 rounded-l-none border-l'
+                  disabled={!hasBlocks}
+                  onClick={() => updateFontSize(currentFontSize + 1)}
+                >
+                  <PlusIcon className='size-3' />
+                </Button>
+              </div>
+            </TooltipTrigger>
+            <TooltipContent side='bottom' sideOffset={4}>
+              {t('render.fontSizeTooltip')}
             </TooltipContent>
           </Tooltip>
         </div>

--- a/ui/components/panels/TextBlocksPanel.tsx
+++ b/ui/components/panels/TextBlocksPanel.tsx
@@ -1,10 +1,10 @@
 'use client'
 
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { motion } from 'motion/react'
 import { TextBlock } from '@/types'
-import { Languages, LoaderCircleIcon, Trash2Icon } from 'lucide-react'
+import { Languages, LoaderCircleIcon, MergeIcon, Trash2Icon } from 'lucide-react'
 import { useTextBlocks } from '@/hooks/useTextBlocks'
 import { useLlmReadyQuery } from '@/lib/query/hooks'
 import { useLlmMutations } from '@/lib/query/mutations'
@@ -22,21 +22,27 @@ import {
 import { Button } from '@/components/ui/button'
 import { DraftTextarea } from '@/components/ui/draft-textarea'
 import { ScrollArea } from '@/components/ui/scroll-area'
+import { cn } from '@/lib/utils'
 
 export function TextBlocksPanel() {
   const {
     document,
     textBlocks,
     selectedBlockIndex,
+    selectedBlockIndices,
     setSelectedBlockIndex,
+    toggleBlockSelection,
     replaceBlock,
     removeBlock,
+    mergeBlocks,
   } = useTextBlocks()
   const { t } = useTranslation()
   const { llmGenerate } = useLlmMutations()
   const { data: llmReady = false } = useLlmReadyQuery()
   const [generatingIndex, setGeneratingIndex] = useState<number | null>(null)
   const generating = generatingIndex !== null
+  const isMultiSelect = selectedBlockIndices.length > 1
+  const selectedIndicesSet = useMemo(() => new Set(selectedBlockIndices), [selectedBlockIndices])
 
   if (!document) {
     return (
@@ -65,6 +71,14 @@ export function TextBlocksPanel() {
     await removeBlock(blockIndex)
   }
 
+  const handleCardClick = (index: number, event: React.MouseEvent) => {
+    if (event.ctrlKey || event.metaKey) {
+      event.preventDefault()
+      event.stopPropagation()
+      toggleBlockSelection(index)
+    }
+  }
+
   return (
     <div
       className='flex min-h-0 flex-1 flex-col'
@@ -74,6 +88,30 @@ export function TextBlocksPanel() {
         <span data-testid='textblocks-count' data-count={textBlocks.length}>
           {t('textBlocks.title', { count: textBlocks.length })}
         </span>
+        {isMultiSelect && (
+          <div className='flex items-center gap-1'>
+            <span className='rounded-full bg-sky-400/20 px-1.5 py-0.5 text-[9px] font-semibold text-sky-600 normal-case dark:text-sky-400'>
+              {t('textBlocks.selected', { count: selectedBlockIndices.length })}
+            </span>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant='ghost'
+                  size='icon-xs'
+                  data-testid='textblocks-merge'
+                  className='size-5'
+                  disabled={generating}
+                  onClick={() => void mergeBlocks(selectedBlockIndices)}
+                >
+                  <MergeIcon className='size-3' />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side='bottom' sideOffset={4}>
+                {t('workspace.mergeBlocks')}
+              </TooltipContent>
+            </Tooltip>
+          </div>
+        )}
       </div>
       <ScrollArea
         className='min-h-0 flex-1'
@@ -106,9 +144,12 @@ export function TextBlocksPanel() {
                   block={block}
                   index={index}
                   selected={index === selectedBlockIndex}
+                  multiSelected={selectedIndicesSet.has(index)}
+                  isMultiSelect={isMultiSelect}
                   onChange={(updates) => void replaceBlock(index, updates)}
                   onDelete={() => void handleDelete(index)}
                   onGenerate={() => void handleGenerate(index)}
+                  onCardClick={(e) => handleCardClick(index, e)}
                   generationInFlight={generating}
                   generating={generatingIndex === index}
                   llmReady={llmReady}
@@ -126,9 +167,12 @@ type BlockCardProps = {
   block: TextBlock
   index: number
   selected: boolean
+  multiSelected: boolean
+  isMultiSelect: boolean
   onChange: (updates: Partial<TextBlock>) => void
   onDelete: () => void | Promise<void>
   onGenerate: () => void | Promise<void>
+  onCardClick: (event: React.MouseEvent) => void
   generationInFlight: boolean
   generating: boolean
   llmReady: boolean
@@ -138,9 +182,12 @@ function BlockCard({
   block,
   index,
   selected,
+  multiSelected,
+  isMultiSelect,
   onChange,
   onDelete,
   onGenerate,
+  onCardClick,
   generationInFlight,
   generating,
   llmReady,
@@ -156,17 +203,31 @@ function BlockCard({
       initial={{ opacity: 0, y: 8 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.2, delay: index * 0.03 }}
+      onClick={onCardClick}
     >
       <AccordionItem
         value={index.toString()}
         data-selected={selected}
-        className='bg-card/90 ring-border data-[selected=true]:ring-primary overflow-hidden rounded text-xs ring-1'
+        data-multi-selected={multiSelected}
+        className={cn(
+          'bg-card/90 overflow-hidden rounded text-xs ring-1',
+          selected
+            ? 'ring-primary'
+            : multiSelected
+              ? 'ring-sky-400'
+              : 'ring-border',
+        )}
       >
         <AccordionTrigger className='data-[state=open]:bg-accent flex w-full cursor-pointer items-center gap-1.5 px-2 py-1.5 text-left transition outline-none hover:no-underline [&>svg]:hidden'>
           <span
-            className={`shrink-0 rounded px-1.5 py-0.5 text-center text-[10px] font-medium text-white tabular-nums ${
-              selected ? 'bg-primary' : 'bg-muted-foreground/60'
-            }`}
+            className={cn(
+              'shrink-0 rounded px-1.5 py-0.5 text-center text-[10px] font-medium text-white tabular-nums',
+              selected
+                ? 'bg-primary'
+                : multiSelected
+                  ? 'bg-sky-400'
+                  : 'bg-muted-foreground/60',
+            )}
             style={{ minWidth: '1.5rem' }}
           >
             {index + 1}

--- a/ui/hooks/useBlockContextMenu.ts
+++ b/ui/hooks/useBlockContextMenu.ts
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import type React from 'react'
 import { Document } from '@/types'
+import { useEditorUiStore } from '@/lib/stores/editorUiStore'
 import type { PointerToDocumentFn } from '@/hooks/usePointerToDocument'
 
 type BlockContextMenuOptions = {
@@ -39,7 +40,13 @@ export function useBlockContextMenu({
         point.y <= block.y + block.height,
     )
     if (blockIndex >= 0) {
-      selectBlock(blockIndex)
+      // Don't reset multi-selection when right-clicking a block that is
+      // already part of it — the user needs the selection to stay so they
+      // can use "Merge blocks" from the context menu.
+      const { selectedBlockIndices } = useEditorUiStore.getState()
+      if (!selectedBlockIndices.includes(blockIndex)) {
+        selectBlock(blockIndex)
+      }
       setContextMenuBlockIndex(blockIndex)
     } else {
       event.preventDefault()

--- a/ui/hooks/useBrushLayerDisplay.ts
+++ b/ui/hooks/useBrushLayerDisplay.ts
@@ -38,6 +38,10 @@ export function useBrushLayerDisplay({
       canvas.height = currentDocument.height
     }
 
+    // Always clear before async load so stale content from a previous page
+    // doesn't flash when both pages share the same canvas dimensions.
+    ctx?.clearRect(0, 0, canvas.width, canvas.height)
+
     let cancelled = false
     const brushLayer = currentDocument.brushLayer
 
@@ -66,8 +70,6 @@ export function useBrushLayerDisplay({
           console.error(error)
         }
       })()
-    } else {
-      ctx?.clearRect(0, 0, canvas.width, canvas.height)
     }
 
     return () => {

--- a/ui/hooks/useTextBlocks.ts
+++ b/ui/hooks/useTextBlocks.ts
@@ -1,13 +1,25 @@
 'use client'
 
-import { useEffect, useRef } from 'react'
+import { useRef, useCallback } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import { useCurrentDocumentState } from '@/lib/query/hooks'
 import { useTextBlockMutations } from '@/lib/query/mutations'
 import { createTempTextBlockId } from '@/lib/api'
 import { useEditorUiStore } from '@/lib/stores/editorUiStore'
-import { TextBlock } from '@/types'
+import { useUndoStore } from '@/lib/stores/undoStore'
+import { queryKeys } from '@/lib/query/keys'
+import { TextBlock, Document } from '@/types'
+import { enqueueTextBlockSync } from '@/lib/services/syncQueues'
 
 const TEXT_BLOCK_RENDER_DEBOUNCE_MS = 250
+const POSITION_SYNC_DEBOUNCE_MS = 400
+
+// Module-level singletons so all useTextBlocks() instances share the same
+// debounce timers.  Without this, each component that calls the hook gets its
+// own timer refs – two components editing the same block fire two render
+// requests instead of one.
+const sharedRenderTimers = new Map<number, ReturnType<typeof setTimeout>>()
+let sharedPositionSyncTimer: ReturnType<typeof setTimeout> | null = null
 
 const shouldRenderSprite = (updates: Partial<TextBlock>) =>
   Object.prototype.hasOwnProperty.call(updates, 'width') ||
@@ -25,51 +37,134 @@ const hasGeometryChange = (updates: Partial<TextBlock>) =>
   Object.prototype.hasOwnProperty.call(updates, 'width') ||
   Object.prototype.hasOwnProperty.call(updates, 'height')
 
+const isPositionOnlyChange = (updates: Partial<TextBlock>) => {
+  const keys = Object.keys(updates)
+  return keys.length > 0 && keys.every((k) => k === 'x' || k === 'y')
+}
+
 export function useTextBlocks() {
+  const queryClient = useQueryClient()
   const { currentDocument: document, currentDocumentIndex } =
     useCurrentDocumentState()
   const textBlocks = document?.textBlocks ?? []
   const selectedBlockIndex = useEditorUiStore(
     (state) => state.selectedBlockIndex,
   )
+  const selectedBlockIndices = useEditorUiStore(
+    (state) => state.selectedBlockIndices,
+  )
   const setSelectedBlockIndex = useEditorUiStore(
     (state) => state.setSelectedBlockIndex,
   )
+  const toggleBlockSelection = useEditorUiStore(
+    (state) => state.toggleBlockSelection,
+  )
+  const clearBlockSelection = useEditorUiStore(
+    (state) => state.clearBlockSelection,
+  )
   const { updateTextBlocks, renderTextBlock } = useTextBlockMutations()
-  const renderTimersRef = useRef<Map<number, ReturnType<typeof setTimeout>>>(
-    new Map(),
+  const pushUndo = useUndoStore((state) => state.push)
+  // Track the block state at drag-start to create a single undo entry per drag session
+  const dragUndoRef = useRef<{
+    index: number
+    snapshot: TextBlock
+  } | null>(null)
+
+  /** Read the latest textBlocks directly from React Query cache (never stale). */
+  const readCurrentBlocks = useCallback((): TextBlock[] => {
+    const idx = useEditorUiStore.getState().currentDocumentIndex
+    const doc = queryClient.getQueryData<Document>(
+      queryKeys.documents.current(idx),
+    )
+    return doc?.textBlocks ?? []
+  }, [queryClient])
+
+  /** Optimistically update textBlocks in the React Query cache without hitting the backend. */
+  const setCacheBlocks = useCallback(
+    (nextBlocks: TextBlock[]) => {
+      const idx = useEditorUiStore.getState().currentDocumentIndex
+      const queryKey = queryKeys.documents.current(idx)
+      void queryClient.cancelQueries({ queryKey })
+      const doc = queryClient.getQueryData<any>(queryKey)
+      if (!doc) return
+      queryClient.setQueryData(queryKey, { ...doc, textBlocks: nextBlocks })
+    },
+    [queryClient],
   )
 
-  useEffect(() => {
-    const timers = renderTimersRef.current
-    return () => {
-      timers.forEach((timer) => clearTimeout(timer))
-      timers.clear()
-    }
-  }, [])
-
   const clearScheduledRender = (index: number) => {
-    const timer = renderTimersRef.current.get(index)
+    const timer = sharedRenderTimers.get(index)
     if (!timer) return
     clearTimeout(timer)
-    renderTimersRef.current.delete(index)
+    sharedRenderTimers.delete(index)
   }
 
   const scheduleRender = (index: number) => {
     clearScheduledRender(index)
     const timer = setTimeout(() => {
-      renderTimersRef.current.delete(index)
-      void renderTextBlock(undefined, currentDocumentIndex, index)
+      sharedRenderTimers.delete(index)
+      // Read currentDocumentIndex from the store at fire time so a page
+      // change during the debounce window doesn't render on the old page.
+      const docIdx = useEditorUiStore.getState().currentDocumentIndex
+      void renderTextBlock(undefined, docIdx, index)
     }, TEXT_BLOCK_RENDER_DEBOUNCE_MS)
-    renderTimersRef.current.set(index, timer)
+    sharedRenderTimers.set(index, timer)
   }
 
   const replaceBlock = async (index: number, updates: Partial<TextBlock>) => {
-    const currentBlocks = document?.textBlocks ?? []
+    const currentBlocks = readCurrentBlocks()
+    const oldBlock = currentBlocks[index]
+    if (!oldBlock) return
     const nextBlocks = currentBlocks.map((block, idx) =>
       idx === index ? { ...block, ...updates } : block,
     )
-    await updateTextBlocks(nextBlocks)
+
+    if (isPositionOnlyChange(updates)) {
+      // FIX: Update cache immediately so the UI shows the new position at once.
+      // Only debounce the backend sync.
+      setCacheBlocks(nextBlocks)
+
+      if (sharedPositionSyncTimer) {
+        clearTimeout(sharedPositionSyncTimer)
+      }
+      sharedPositionSyncTimer = setTimeout(() => {
+        sharedPositionSyncTimer = null
+        // Read the LATEST cache (user may have moved more since this was scheduled)
+        const latestBlocks = readCurrentBlocks()
+        const idx = useEditorUiStore.getState().currentDocumentIndex
+        void enqueueTextBlockSync(idx, latestBlocks)
+      }, POSITION_SYNC_DEBOUNCE_MS)
+
+      // Undo for position: capture snapshot at drag-start only (not every intermediate move)
+      if (!dragUndoRef.current || dragUndoRef.current.index !== index) {
+        dragUndoRef.current = { index, snapshot: { ...oldBlock } }
+      }
+    } else {
+      // Non-position changes: update cache + sync immediately
+      await updateTextBlocks(nextBlocks)
+
+      // Push undo (non-position changes)
+      const snapshot = { ...oldBlock }
+      const applied = { ...updates }
+      pushUndo({
+        type: 'replaceBlock',
+        description: `Edit block ${index + 1}`,
+        undo: () => {
+          const blocks = readCurrentBlocks()
+          const restored = blocks.map((b, idx) =>
+            idx === index ? snapshot : b,
+          )
+          void updateTextBlocks(restored)
+        },
+        redo: () => {
+          const blocks = readCurrentBlocks()
+          const reapplied = blocks.map((b, idx) =>
+            idx === index ? { ...b, ...applied } : b,
+          )
+          void updateTextBlocks(reapplied)
+        },
+      })
+    }
 
     if (hasGeometryChange(updates)) {
       const ui = useEditorUiStore.getState()
@@ -77,51 +172,307 @@ export function useTextBlocks() {
       ui.setShowTextBlocksOverlay(true)
     }
 
-    const doc = document
-
     if (shouldRenderSprite(updates)) {
+      const docIdx = useEditorUiStore.getState().currentDocumentIndex
       if (shouldRenderSpriteImmediately(updates)) {
         clearScheduledRender(index)
-        void renderTextBlock(undefined, currentDocumentIndex, index)
+        void renderTextBlock(undefined, docIdx, index)
       } else {
         scheduleRender(index)
       }
     }
   }
 
-  const appendBlock = async (block: TextBlock) => {
-    const currentBlocks = document?.textBlocks ?? []
-    const nextBlocks = [
-      ...currentBlocks,
-      {
-        ...block,
-        id: block.id ?? createTempTextBlockId(),
+  /** Call after a drag session ends to commit the undo entry for the whole drag. */
+  const commitDragUndo = useCallback(() => {
+    const entry = dragUndoRef.current
+    if (!entry) return
+    dragUndoRef.current = null
+
+    const { index, snapshot } = entry
+    const finalBlock = readCurrentBlocks()[index]
+    if (!finalBlock) return
+    // Don't push if position didn't actually change
+    if (finalBlock.x === snapshot.x && finalBlock.y === snapshot.y) return
+
+    const finalPos = { x: finalBlock.x, y: finalBlock.y }
+    pushUndo({
+      type: 'moveBlock',
+      description: `Move block ${index + 1}`,
+      undo: () => {
+        const blocks = readCurrentBlocks()
+        const restored = blocks.map((b, idx) =>
+          idx === index ? { ...b, x: snapshot.x, y: snapshot.y } : b,
+        )
+        void updateTextBlocks(restored)
       },
-    ]
+      redo: () => {
+        const blocks = readCurrentBlocks()
+        const reapplied = blocks.map((b, idx) =>
+          idx === index ? { ...b, x: finalPos.x, y: finalPos.y } : b,
+        )
+        void updateTextBlocks(reapplied)
+      },
+    })
+  }, [pushUndo, readCurrentBlocks, updateTextBlocks])
+
+  const replaceMultipleBlocks = async (
+    indices: number[],
+    updates: Partial<TextBlock>,
+  ) => {
+    const currentBlocks = readCurrentBlocks()
+    const indexSet = new Set(indices)
+    const snapshots = new Map<number, TextBlock>()
+    indices.forEach((i) => {
+      if (currentBlocks[i]) snapshots.set(i, { ...currentBlocks[i] })
+    })
+
+    const nextBlocks = currentBlocks.map((block, idx) =>
+      indexSet.has(idx) ? { ...block, ...updates } : block,
+    )
     await updateTextBlocks(nextBlocks)
-    setSelectedBlockIndex(nextBlocks.length - 1)
+
+    pushUndo({
+      type: 'replaceMultipleBlocks',
+      description: `Edit ${indices.length} blocks`,
+      undo: () => {
+        const blocks = readCurrentBlocks()
+        const restored = blocks.map((b, idx) => snapshots.get(idx) ?? b)
+        void updateTextBlocks(restored)
+      },
+      redo: () => {
+        const blocks = readCurrentBlocks()
+        const reapplied = blocks.map((b, idx) =>
+          indexSet.has(idx) ? { ...b, ...updates } : b,
+        )
+        void updateTextBlocks(reapplied)
+      },
+    })
+
+    if (hasGeometryChange(updates)) {
+      const ui = useEditorUiStore.getState()
+      ui.setShowRenderedImage(false)
+      ui.setShowTextBlocksOverlay(true)
+    }
+
+    if (shouldRenderSprite(updates)) {
+      const docIdx = useEditorUiStore.getState().currentDocumentIndex
+      for (const idx of indices) {
+        if (shouldRenderSpriteImmediately(updates)) {
+          clearScheduledRender(idx)
+          void renderTextBlock(undefined, docIdx, idx)
+        } else {
+          scheduleRender(idx)
+        }
+      }
+    }
+  }
+
+  const appendBlock = async (block: TextBlock) => {
+    const currentBlocks = readCurrentBlocks()
+    const newBlock = {
+      ...block,
+      id: block.id ?? createTempTextBlockId(),
+    }
+    const nextBlocks = [...currentBlocks, newBlock]
+    await updateTextBlocks(nextBlocks)
+    const addedIndex = nextBlocks.length - 1
+    setSelectedBlockIndex(addedIndex)
+
+    const blockCopy = { ...newBlock }
+    pushUndo({
+      type: 'appendBlock',
+      description: `Add block ${addedIndex + 1}`,
+      undo: () => {
+        const blocks = readCurrentBlocks()
+        void updateTextBlocks(blocks.slice(0, -1))
+        setSelectedBlockIndex(undefined)
+      },
+      redo: () => {
+        const blocks = readCurrentBlocks()
+        void updateTextBlocks([...blocks, blockCopy])
+        setSelectedBlockIndex(blocks.length)
+      },
+    })
   }
 
   const removeBlock = async (index: number) => {
     clearScheduledRender(index)
-    const currentBlocks = document?.textBlocks ?? []
+    const currentBlocks = readCurrentBlocks()
+    const removedBlock = currentBlocks[index]
     const nextBlocks = currentBlocks.filter((_, idx) => idx !== index)
     await updateTextBlocks(nextBlocks)
     setSelectedBlockIndex(undefined)
+
+    if (removedBlock) {
+      const blockCopy = { ...removedBlock }
+      pushUndo({
+        type: 'removeBlock',
+        description: `Delete block ${index + 1}`,
+        undo: () => {
+          const blocks = readCurrentBlocks()
+          const restored = [
+            ...blocks.slice(0, index),
+            blockCopy,
+            ...blocks.slice(index),
+          ]
+          void updateTextBlocks(restored)
+          setSelectedBlockIndex(index)
+        },
+        redo: () => {
+          const blocks = readCurrentBlocks()
+          void updateTextBlocks(blocks.filter((_, idx) => idx !== index))
+          setSelectedBlockIndex(undefined)
+        },
+      })
+    }
   }
 
-  const clearSelection = () => {
-    setSelectedBlockIndex(undefined)
+  const mergeBlocks = async (indices: number[]) => {
+    if (indices.length < 2) return
+    const currentBlocks = readCurrentBlocks()
+    const toMerge = indices
+      .map((i) => ({ index: i, block: currentBlocks[i] }))
+      .filter((entry) => !!entry.block)
+    if (toMerge.length < 2) return
+
+    // Sort by Y coordinate (top to bottom) for text concatenation order
+    const sorted = [...toMerge].sort((a, b) => a.block.y - b.block.y)
+
+    // Union bounding box
+    let minX = Infinity
+    let minY = Infinity
+    let maxX = -Infinity
+    let maxY = -Infinity
+    for (const { block } of sorted) {
+      minX = Math.min(minX, block.x)
+      minY = Math.min(minY, block.y)
+      maxX = Math.max(maxX, block.x + block.width)
+      maxY = Math.max(maxY, block.y + block.height)
+    }
+
+    // Find the largest block (by area) for style/font/direction
+    const largest = toMerge.reduce((best, curr) => {
+      const bestArea = best.block.width * best.block.height
+      const currArea = curr.block.width * curr.block.height
+      return currArea > bestArea ? curr : best
+    })
+
+    // Concatenate text and translation in Y order, separated by newline
+    const mergedText = sorted
+      .map((e) => e.block.text?.trim())
+      .filter(Boolean)
+      .join('\n')
+    const mergedTranslation = sorted
+      .map((e) => e.block.translation?.trim())
+      .filter(Boolean)
+      .join('\n')
+
+    const mergedBlock: TextBlock = {
+      id: createTempTextBlockId(),
+      x: Math.round(minX),
+      y: Math.round(minY),
+      width: Math.round(maxX - minX),
+      height: Math.round(maxY - minY),
+      confidence: Math.max(...toMerge.map((e) => e.block.confidence)),
+      sourceDirection: largest.block.sourceDirection,
+      renderedDirection: largest.block.renderedDirection,
+      sourceLanguage: largest.block.sourceLanguage,
+      detectedFontSizePx: largest.block.detectedFontSizePx,
+      detector: largest.block.detector,
+      text: mergedText || undefined,
+      translation: mergedTranslation || undefined,
+      style: largest.block.style,
+      fontPrediction: largest.block.fontPrediction,
+    }
+
+    // Remove merged blocks and insert the new one at the position of the
+    // first (topmost) merged block so the numbering stays intuitive.
+    const removeSet = new Set(indices)
+    const nextBlocks: TextBlock[] = []
+    let inserted = false
+    for (let i = 0; i < currentBlocks.length; i++) {
+      if (removeSet.has(i)) {
+        clearScheduledRender(i)
+        if (!inserted) {
+          nextBlocks.push(mergedBlock)
+          inserted = true
+        }
+        continue
+      }
+      nextBlocks.push(currentBlocks[i])
+    }
+    if (!inserted) nextBlocks.push(mergedBlock)
+
+    const mergedIndex = nextBlocks.indexOf(mergedBlock)
+
+    // Push undo BEFORE the async updateTextBlocks so Ctrl+Z is available
+    // immediately, not after the backend sync completes.
+    const snapshotBlocks = currentBlocks.map((b) => ({ ...b }))
+    const mergedBlockCopy = { ...mergedBlock }
+    pushUndo({
+      type: 'mergeBlocks',
+      description: `Merge ${indices.length} blocks`,
+      undo: () => {
+        void updateTextBlocks(snapshotBlocks)
+        clearBlockSelection()
+      },
+      redo: () => {
+        const redoBlocks: TextBlock[] = []
+        const set = new Set(indices)
+        let ins = false
+        for (const [i, b] of snapshotBlocks.entries()) {
+          if (set.has(i)) {
+            if (!ins) {
+              redoBlocks.push(mergedBlockCopy)
+              ins = true
+            }
+            continue
+          }
+          redoBlocks.push(b)
+        }
+        if (!ins) redoBlocks.push(mergedBlockCopy)
+        void updateTextBlocks(redoBlocks)
+        const idx = redoBlocks.indexOf(mergedBlockCopy)
+        setSelectedBlockIndex(idx >= 0 ? idx : undefined)
+      },
+    })
+
+    // Clear stale multi-select indices BEFORE updating blocks so that a
+    // React re-render during the async sync doesn't display old indices
+    // pointing at wrong blocks in the new array.
+    clearBlockSelection()
+    await updateTextBlocks(nextBlocks)
+    setSelectedBlockIndex(mergedIndex)
+
+    // Show text block overlay and hide rendered image since geometry changed
+    const ui = useEditorUiStore.getState()
+    ui.setShowRenderedImage(false)
+    ui.setShowTextBlocksOverlay(true)
+
+    // Trigger render for the new merged block
+    const docIdx = useEditorUiStore.getState().currentDocumentIndex
+    void renderTextBlock(undefined, docIdx, mergedIndex)
   }
+
+  const clearSelection = useCallback(() => {
+    clearBlockSelection()
+  }, [clearBlockSelection])
 
   return {
     document,
     textBlocks,
     selectedBlockIndex,
+    selectedBlockIndices,
     setSelectedBlockIndex,
+    toggleBlockSelection,
     clearSelection,
     replaceBlock,
+    replaceMultipleBlocks,
+    readCurrentBlocks,
+    mergeBlocks,
     appendBlock,
     removeBlock,
+    commitDragUndo,
   }
 }

--- a/ui/lib/stores/editorUiStore.ts
+++ b/ui/lib/stores/editorUiStore.ts
@@ -2,6 +2,15 @@
 
 import { create } from 'zustand'
 import { RenderEffect, RenderStroke, ToolMode } from '@/types'
+import { useUndoStore } from '@/lib/stores/undoStore'
+
+type LayerVisibility = {
+  showSegmentationMask: boolean
+  showInpaintedImage: boolean
+  showBrushLayer: boolean
+  showRenderedImage: boolean
+  showTextBlocksOverlay: boolean
+}
 
 type EditorUiState = {
   totalPages: number
@@ -13,8 +22,11 @@ type EditorUiState = {
   showBrushLayer: boolean
   showRenderedImage: boolean
   showTextBlocksOverlay: boolean
+  showOriginalOnly: boolean
+  savedLayerVisibility: LayerVisibility | null
   mode: ToolMode
   selectedBlockIndex?: number
+  selectedBlockIndices: number[]
   autoFitEnabled: boolean
   renderEffect: RenderEffect
   renderStroke: RenderStroke
@@ -26,8 +38,11 @@ type EditorUiState = {
   setShowBrushLayer: (show: boolean) => void
   setShowRenderedImage: (show: boolean) => void
   setShowTextBlocksOverlay: (show: boolean) => void
+  setShowOriginalOnly: (show: boolean) => void
   setMode: (mode: ToolMode) => void
   setSelectedBlockIndex: (index?: number) => void
+  toggleBlockSelection: (index: number) => void
+  clearBlockSelection: () => void
   setAutoFitEnabled: (enabled: boolean) => void
   setRenderEffect: (effect: RenderEffect) => void
   setRenderStroke: (stroke: RenderStroke) => void
@@ -44,8 +59,11 @@ const initialState = {
   showBrushLayer: false,
   showRenderedImage: false,
   showTextBlocksOverlay: false,
+  showOriginalOnly: false,
+  savedLayerVisibility: null as LayerVisibility | null,
   mode: 'select' as ToolMode,
-  selectedBlockIndex: undefined,
+  selectedBlockIndex: undefined as number | undefined,
+  selectedBlockIndices: [] as number[],
   autoFitEnabled: true,
   renderEffect: {
     italic: false,
@@ -68,16 +86,23 @@ export const useEditorUiStore = create<EditorUiState>((set, get) => ({
         documentsVersion: state.documentsVersion + 1,
         currentDocumentIndex: 0,
         selectedBlockIndex: undefined,
+        selectedBlockIndices: [],
       }
     })
   },
-  setCurrentDocumentIndex: (index) =>
+  setCurrentDocumentIndex: (index) => {
     set(() => ({
       currentDocumentIndex: index,
       selectedBlockIndex: undefined,
-    })),
+      selectedBlockIndices: [],
+    }))
+    // Undo actions reference the page they were created on.  Leaving them
+    // in the stack after a page switch causes Ctrl+Z to silently modify a
+    // page the user is no longer viewing.
+    useUndoStore.getState().clear()
+  },
   setScale: (scale) => {
-    const clamped = Math.max(10, Math.min(100, Math.round(scale)))
+    const clamped = Math.max(10, Math.min(400, Math.round(scale)))
     set({ scale: clamped })
   },
   setShowSegmentationMask: (show) => set({ showSegmentationMask: show }),
@@ -85,10 +110,42 @@ export const useEditorUiStore = create<EditorUiState>((set, get) => ({
   setShowBrushLayer: (show) => set({ showBrushLayer: show }),
   setShowRenderedImage: (show) => set({ showRenderedImage: show }),
   setShowTextBlocksOverlay: (show) => set({ showTextBlocksOverlay: show }),
+  setShowOriginalOnly: (show) => {
+    const state = get()
+    if (show) {
+      set({
+        showOriginalOnly: true,
+        savedLayerVisibility: {
+          showSegmentationMask: state.showSegmentationMask,
+          showInpaintedImage: state.showInpaintedImage,
+          showBrushLayer: state.showBrushLayer,
+          showRenderedImage: state.showRenderedImage,
+          showTextBlocksOverlay: state.showTextBlocksOverlay,
+        },
+        showSegmentationMask: false,
+        showInpaintedImage: false,
+        showBrushLayer: false,
+        showRenderedImage: false,
+        showTextBlocksOverlay: false,
+      })
+    } else {
+      const saved = state.savedLayerVisibility
+      set({
+        showOriginalOnly: false,
+        savedLayerVisibility: null,
+        ...(saved ?? {}),
+      })
+    }
+  },
   setMode: (mode) => {
     set({ mode })
 
-    if (mode === 'repairBrush' || mode === 'brush' || mode === 'eraser') {
+    if (
+      mode === 'repairBrush' ||
+      mode === 'brush' ||
+      mode === 'eraser' ||
+      mode === 'magicEraser'
+    ) {
       set({
         showRenderedImage: false,
         showInpaintedImage: true,
@@ -99,6 +156,11 @@ export const useEditorUiStore = create<EditorUiState>((set, get) => ({
       set({
         showTextBlocksOverlay: true,
         showSegmentationMask: true,
+        showBrushLayer: false,
+      })
+    } else if (mode === 'magicEraser') {
+      set({
+        showSegmentationMask: false,
         showBrushLayer: false,
       })
     } else if (mode !== 'eraser') {
@@ -115,7 +177,25 @@ export const useEditorUiStore = create<EditorUiState>((set, get) => ({
       }
     }
   },
-  setSelectedBlockIndex: (index) => set({ selectedBlockIndex: index }),
+  setSelectedBlockIndex: (index) =>
+    set({
+      selectedBlockIndex: index,
+      selectedBlockIndices: index !== undefined ? [index] : [],
+    }),
+  toggleBlockSelection: (index) => {
+    const state = get()
+    const current = state.selectedBlockIndices
+    const exists = current.includes(index)
+    const next = exists
+      ? current.filter((i) => i !== index)
+      : [...current, index]
+    set({
+      selectedBlockIndices: next,
+      selectedBlockIndex: next.length > 0 ? next[next.length - 1] : undefined,
+    })
+  },
+  clearBlockSelection: () =>
+    set({ selectedBlockIndex: undefined, selectedBlockIndices: [] }),
   setAutoFitEnabled: (enabled) => set({ autoFitEnabled: enabled }),
   setRenderEffect: (effect) => set({ renderEffect: effect }),
   setRenderStroke: (stroke) => set({ renderStroke: stroke }),

--- a/ui/lib/stores/undoStore.ts
+++ b/ui/lib/stores/undoStore.ts
@@ -1,0 +1,59 @@
+'use client'
+
+import { create } from 'zustand'
+
+const MAX_HISTORY = 50
+
+export type UndoableAction = {
+  type: string
+  description?: string
+  undo: () => Promise<void> | void
+  redo: () => Promise<void> | void
+}
+
+type UndoState = {
+  past: UndoableAction[]
+  future: UndoableAction[]
+  push: (action: UndoableAction) => void
+  undo: () => Promise<void>
+  redo: () => Promise<void>
+  clear: () => void
+}
+
+export const useUndoStore = create<UndoState>((set, get) => ({
+  past: [],
+  future: [],
+
+  push: (action) => {
+    set((state) => ({
+      past: [...state.past.slice(-MAX_HISTORY + 1), action],
+      future: [],
+    }))
+  },
+
+  undo: async () => {
+    const { past, future } = get()
+    if (past.length === 0) return
+    const action = past[past.length - 1]
+    try {
+      await action.undo()
+      set({ past: past.slice(0, -1), future: [action, ...future] })
+    } catch (err) {
+      console.error('[undo] action failed, history unchanged:', err)
+    }
+  },
+
+  redo: async () => {
+    const { past, future } = get()
+    if (future.length === 0) return
+    const action = future[0]
+    try {
+      await action.redo()
+      set({ past: [...past, action], future: future.slice(1) })
+    } catch (err) {
+      console.error('[redo] action failed, history unchanged:', err)
+    }
+  },
+
+  clear: () => set({ past: [], future: [] }),
+}))

--- a/ui/public/locales/en-US/translation.json
+++ b/ui/public/locales/en-US/translation.json
@@ -184,7 +184,8 @@
   },
   "workspace": {
     "importPrompt": "Import a page to begin editing.",
-    "deleteBlock": "Delete block"
+    "deleteBlock": "Delete block",
+    "mergeBlocks": "Merge blocks"
   },
   "statusBar": {
     "zoom": "Zoom",

--- a/ui/public/locales/es-ES/translation.json
+++ b/ui/public/locales/es-ES/translation.json
@@ -184,7 +184,8 @@
   },
   "workspace": {
     "importPrompt": "Importa una página para comenzar a editar.",
-    "deleteBlock": "Eliminar bloque"
+    "deleteBlock": "Eliminar bloque",
+    "mergeBlocks": "Fusionar bloques"
   },
   "statusBar": {
     "zoom": "Zoom",

--- a/ui/public/locales/ja-JP/translation.json
+++ b/ui/public/locales/ja-JP/translation.json
@@ -184,7 +184,8 @@
   },
   "workspace": {
     "importPrompt": "ページを読み込んで編集を開始してください。",
-    "deleteBlock": "ブロックを削除"
+    "deleteBlock": "ブロックを削除",
+    "mergeBlocks": "ブロックを結合"
   },
   "statusBar": {
     "zoom": "ズーム",

--- a/ui/public/locales/ru-RU/translation.json
+++ b/ui/public/locales/ru-RU/translation.json
@@ -184,7 +184,8 @@
   },
   "workspace": {
     "importPrompt": "Импортируйте страницу, чтобы начать редактирование.",
-    "deleteBlock": "Удалить блок"
+    "deleteBlock": "Удалить блок",
+    "mergeBlocks": "Объединить блоки"
   },
   "statusBar": {
     "zoom": "Масштаб",

--- a/ui/public/locales/zh-CN/translation.json
+++ b/ui/public/locales/zh-CN/translation.json
@@ -184,7 +184,8 @@
   },
   "workspace": {
     "importPrompt": "导入页面以开始编辑。",
-    "deleteBlock": "删除块"
+    "deleteBlock": "删除块",
+    "mergeBlocks": "合并文本块"
   },
   "statusBar": {
     "zoom": "缩放",

--- a/ui/public/locales/zh-TW/translation.json
+++ b/ui/public/locales/zh-TW/translation.json
@@ -184,7 +184,8 @@
   },
   "workspace": {
     "importPrompt": "匯入頁面以開始編輯。",
-    "deleteBlock": "刪除區塊"
+    "deleteBlock": "刪除區塊",
+    "mergeBlocks": "合併文字區塊"
   },
   "statusBar": {
     "zoom": "縮放",

--- a/ui/types.d.ts
+++ b/ui/types.d.ts
@@ -70,7 +70,7 @@ export type TextBlock = {
   rendered?: Uint8Array
 }
 
-export type ToolMode = 'select' | 'block' | 'brush' | 'repairBrush' | 'eraser'
+export type ToolMode = 'select' | 'block' | 'brush' | 'repairBrush' | 'eraser' | 'magicEraser'
 
 export type InpaintRegion = {
   x: number


### PR DESCRIPTION
## Summary
- **Performance**: module-level debounce singletons, `useMemo(Set)` for O(1) lookups, store reads at fire time to avoid stale closures
- **Block merge**: `mergeBlocks()` with union bbox, Y-sorted text concat, Ctrl+M hotkey, context menu, full undo/redo
- **Multi-select**: Ctrl+click via `onPointerDownCapture`, right-click preserves selection
- **Fixes**: brush canvas stale content flash, undo stack cleared on page switch, Tauri resize listener registered once, undoStore executes action before mutating stacks

## Test plan
- [ ] Ctrl+click multi-selects blocks on canvas
- [ ] Select 2+ blocks → merge (Ctrl+M or button) creates correct union block
- [ ] Undo/redo merge works correctly
- [ ] Switching pages clears undo stack
- [ ] No stale brush content flash when switching between same-dimension pages
- [ ] Font size / style changes on multi-selection are undoable
- [ ] Right-click on selected block preserves multi-selection