### PR TITLE
feat: magic eraser — free-form inpaint via mask

### DIFF
--- a/koharu-pipeline/src/ops/edit.rs
+++ b/koharu-pipeline/src/ops/edit.rs
@@ -533,16 +533,25 @@ pub async fn inpaint_partial(
 ) -> anyhow::Result<()> {
     let snapshot = state_tx::read_doc(&state.state, payload.index).await?;
 
-    let mask_image = snapshot
-        .segment
-        .as_ref()
-        .ok_or_else(|| anyhow::anyhow!("Segment image not found"))?;
+    let (img_width, img_height) = (snapshot.width, snapshot.height);
+
+    // In free mode (Magic Eraser), fall back to a blank mask if segment is absent.
+    // In normal mode, require the segment to exist.
+    let fallback_mask;
+    let mask_image = if payload.free {
+        fallback_mask = blank_rgba(img_width, img_height, image::Rgba([0, 0, 0, 255]));
+        snapshot.segment.as_ref().unwrap_or(&fallback_mask)
+    } else {
+        snapshot
+            .segment
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("Segment image not found"))?
+    };
 
     if payload.region.width == 0 || payload.region.height == 0 {
         return Ok(());
     }
 
-    let (img_width, img_height) = (snapshot.width, snapshot.height);
     let x0 = payload.region.x.min(img_width.saturating_sub(1));
     let y0 = payload.region.y.min(img_height.saturating_sub(1));
     let x1 = payload
@@ -562,11 +571,18 @@ pub async fn inpaint_partial(
         return Ok(());
     }
 
-    let localized_blocks =
-        localize_inpaint_text_blocks(&snapshot.text_blocks, x0, y0, crop_width, crop_height);
-    if localized_blocks.is_empty() {
-        return Ok(());
-    }
+    // In free mode, skip text block requirement and pass None to inpaint purely from mask.
+    // In normal mode, require overlapping text blocks.
+    let text_blocks = if payload.free {
+        None
+    } else {
+        let localized_blocks =
+            localize_inpaint_text_blocks(&snapshot.text_blocks, x0, y0, crop_width, crop_height);
+        if localized_blocks.is_empty() {
+            return Ok(());
+        }
+        Some(localized_blocks)
+    };
 
     let image_crop =
         SerializableDynamicImage(snapshot.image.crop_imm(x0, y0, crop_width, crop_height));
@@ -574,7 +590,7 @@ pub async fn inpaint_partial(
 
     let inpainted_crop = state
         .ml
-        .inpaint_raw(&image_crop, &mask_crop, Some(&localized_blocks))
+        .inpaint_raw(&image_crop, &mask_crop, text_blocks.as_deref())
         .await?;
 
     let mut stitched = snapshot

--- a/koharu-rpc/src/api.rs
+++ b/koharu-rpc/src/api.rs
@@ -445,6 +445,7 @@ async fn inpaint_region(
         InpaintPartialPayload {
             index,
             region: to_inpaint_region(request.region),
+            free: request.free,
         },
     )
     .await?;

--- a/koharu-rpc/src/mcp/mod.rs
+++ b/koharu-rpc/src/mcp/mod.rs
@@ -547,6 +547,7 @@ impl KoharuMcp {
                     width: p.width,
                     height: p.height,
                 },
+                free: false,
             },
         )
         .await

--- a/koharu-types/src/commands.rs
+++ b/koharu-types/src/commands.rs
@@ -22,6 +22,17 @@ pub struct IndexPayload {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct DetectPayload {
+    pub index: usize,
+    /// Use lower thresholds to catch more text (higher recall).
+    #[serde(default)]
+    pub sensitive: bool,
+    /// Optional sub-region to restrict detection.
+    pub region: Option<InpaintRegion>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ThumbnailResult {
     #[serde(with = "serde_bytes")]
     pub data: Vec<u8>,
@@ -180,6 +191,9 @@ pub struct UpdateBrushLayerPayload {
 pub struct InpaintPartialPayload {
     pub index: usize,
     pub region: InpaintRegion,
+    /// When true, inpaint purely from the mask without requiring text blocks (Magic Eraser).
+    #[serde(default)]
+    pub free: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -455,6 +469,7 @@ mod tests {
                 width: 10,
                 height: 11,
             },
+            free: false,
         });
         round_trip(&ViewImageParams {
             index: 1,

--- a/koharu-types/src/protocol.rs
+++ b/koharu-types/src/protocol.rs
@@ -398,4 +398,19 @@ pub struct BrushRegionRequest {
 #[ts(export)]
 pub struct InpaintRegionRequest {
     pub region: Region,
+    /// When true, inpaint purely from the mask without requiring text blocks (Magic Eraser).
+    #[serde(default)]
+    pub free: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export)]
+pub struct DetectRequest {
+    /// When true, uses lower confidence thresholds and smaller minimum block
+    /// sizes to catch more text (higher recall at the cost of more false positives).
+    #[serde(default)]
+    pub sensitive: bool,
+    /// Optional region to restrict detection to a sub-area of the image.
+    pub region: Option<Region>,
 }

--- a/ui/hooks/useMaskDrawing.ts
+++ b/ui/hooks/useMaskDrawing.ts
@@ -2,9 +2,13 @@
 
 import { useEffect, useRef } from 'react'
 import { useDrag } from '@use-gesture/react'
+import { useQueryClient } from '@tanstack/react-query'
 import { usePreferencesStore } from '@/lib/stores/preferencesStore'
 import { useEditorUiStore } from '@/lib/stores/editorUiStore'
+import { useUiErrorStore } from '@/lib/stores/uiErrorStore'
+import { useUndoStore } from '@/lib/stores/undoStore'
 import { useMaskMutations } from '@/lib/query/mutations'
+import { queryKeys } from '@/lib/query/keys'
 import { blobToUint8Array, convertToImageBitmap } from '@/lib/util'
 import { Document, InpaintRegion, ToolMode } from '@/types'
 import {
@@ -92,10 +96,9 @@ export function useMaskDrawing({
   const {
     brushConfig: { size: brushSize },
   } = usePreferencesStore()
-  const { updateMask, inpaintPartial } = useMaskMutations()
-  const currentDocumentIndex = useEditorUiStore(
-    (state) => state.currentDocumentIndex,
-  )
+  const queryClient = useQueryClient()
+  const pushUndo = useUndoStore((state) => state.push)
+  const { updateMask, inpaintPartial, inpaintFree } = useMaskMutations()
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
   const ctxRef = useRef<CanvasRenderingContext2D | null>(null)
   const drawingRef = useRef(false)
@@ -103,8 +106,9 @@ export function useMaskDrawing({
   const boundsRef = useRef<Bounds | null>(null)
   const inpaintQueueRef = useRef<Promise<void>>(Promise.resolve())
   const isRepairMode = mode === 'repairBrush'
+  const isMagicEraser = mode === 'magicEraser'
   const isEraseMode = mode === 'eraser'
-  const isActive = enabled && (isRepairMode || isEraseMode)
+  const isActive = enabled && (isRepairMode || isEraseMode || isMagicEraser)
 
   // Reset drawing state when interaction is disabled so stale strokes don't carry over.
   useEffect(() => {
@@ -114,6 +118,17 @@ export function useMaskDrawing({
     boundsRef.current = null
     inpaintQueueRef.current = Promise.resolve()
   }, [enabled, mode])
+
+  // Clear the mask canvas when entering magic eraser mode so the user
+  // doesn't see a leftover segmentation mask from a previous mode.
+  useEffect(() => {
+    if (!isMagicEraser) return
+    const ctx = ctxRef.current
+    const canvas = canvasRef.current
+    if (ctx && canvas) {
+      ctx.clearRect(0, 0, canvas.width, canvas.height)
+    }
+  }, [isMagicEraser])
 
   useEffect(() => {
     const canvas = canvasRef.current
@@ -135,15 +150,17 @@ export function useMaskDrawing({
     if (needsResize) {
       canvas.width = currentDocument.width
       canvas.height = currentDocument.height
-      ctx?.clearRect(0, 0, canvas.width, canvas.height)
-      ctx?.save()
-      ctx && (ctx.fillStyle = '#000')
-      ctx?.fillRect(0, 0, canvas.width, canvas.height)
-      ctx?.restore()
     }
 
+    // Always clear the canvas when the document or segment changes so that
+    // a stale mask from the previous page never bleeds into the current one
+    // (e.g. when pages share the same dimensions and the new page has no segment).
+    ctx?.clearRect(0, 0, canvas.width, canvas.height)
+
+    // In magic eraser mode the canvas is used only for the user's white
+    // stroke preview — don't paint the segmentation mask underneath.
     let cancelled = false
-    if (currentDocument.segment) {
+    if (currentDocument.segment && !isMagicEraser) {
       void (async () => {
         try {
           const bitmap = await convertToImageBitmap(currentDocument.segment!)
@@ -172,6 +189,8 @@ export function useMaskDrawing({
 
     return () => {
       cancelled = true
+      // Clear the canvas so stale masks don't linger during page transitions.
+      ctx?.clearRect(0, 0, canvas.width, canvas.height)
       drawingRef.current = false
       lastPointRef.current = null
       boundsRef.current = null
@@ -182,6 +201,7 @@ export function useMaskDrawing({
     currentDocument?.width,
     currentDocument?.height,
     currentDocument?.segment,
+    isMagicEraser,
   ])
 
   const drawStroke = (from: DocumentPointer, to: DocumentPointer) => {
@@ -251,11 +271,14 @@ export function useMaskDrawing({
     if (!isActive) return
     const strokeBounds = boundsRef.current
     if (!currentDocument || !strokeBounds) return
+
     const patchRegion = boundsToRegion(strokeBounds, currentDocument)
     const region = withMargin(strokeBounds, brushSize, currentDocument)
     boundsRef.current = null
     drawingRef.current = false
     lastPointRef.current = null
+
+    const docIndex = useEditorUiStore.getState().currentDocumentIndex
 
     void (async () => {
       const [maskBytes, patchBytes] = await Promise.all([
@@ -269,15 +292,73 @@ export function useMaskDrawing({
           patch: patchBytes ?? undefined,
         })
       } catch (error) {
-        console.error(error)
+        console.error('[mask] updateMask failed:', error)
+        useUiErrorStore
+          .getState()
+          .showError(
+            error instanceof Error ? error.message : 'Failed to update mask',
+          )
+        return
       }
       queueInpaint(async () => {
+        // Snapshot INSIDE the queue so that when multiple strokes are queued,
+        // each snapshot captures the state AFTER the previous inpaint
+        // completed — not the stale state from before the queue started.
+        const queryKey = queryKeys.documents.current(docIndex)
+        const snapshotDoc = queryClient.getQueryData<Document>(queryKey)
+        const prevInpainted = snapshotDoc?.inpainted
+          ? new Uint8Array(snapshotDoc.inpainted)
+          : undefined
+        const prevSegment = snapshotDoc?.segment
+          ? new Uint8Array(snapshotDoc.segment)
+          : undefined
+
         try {
-          await inpaintPartial(region, {
-            index: currentDocumentIndex,
+          if (isMagicEraser) {
+            await inpaintFree(region, { index: docIndex })
+          } else {
+            await inpaintPartial(region, { index: docIndex })
+          }
+
+          pushUndo({
+            type: isMagicEraser ? 'magicEraser' : 'repairBrush',
+            description: isMagicEraser ? 'Magic Eraser' : 'Repair Brush',
+            undo: () => {
+              const key = queryKeys.documents.current(docIndex)
+              const doc = queryClient.getQueryData<any>(key)
+              if (!doc) return
+              queryClient.setQueryData(key, {
+                ...doc,
+                inpainted: prevInpainted,
+                segment: prevSegment,
+              })
+              if (prevSegment) {
+                void updateMask(prevSegment, { sync: true })
+              }
+            },
+            redo: () => {
+              void (async () => {
+                if (maskBytes) {
+                  await updateMask(maskBytes, {
+                    patchRegion: patchBytes ? patchRegion : undefined,
+                    patch: patchBytes ?? undefined,
+                  })
+                }
+                if (isMagicEraser) {
+                  await inpaintFree(region, { index: docIndex })
+                } else {
+                  await inpaintPartial(region, { index: docIndex })
+                }
+              })()
+            },
           })
         } catch (error) {
-          console.error(error)
+          console.error('[mask] inpaint failed:', error)
+          useUiErrorStore
+            .getState()
+            .showError(
+              error instanceof Error ? error.message : 'Inpaint failed',
+            )
         }
       })
     })()

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -522,6 +522,18 @@ export const api = {
     })
   },
 
+  async inpaintFree(index: number, region: InpaintRegion): Promise<void> {
+    return withRpcError('inpaint_partial', async () => {
+      const summary = await getDocumentSummaryAtIndex(index)
+      await fetchJson<void>(`/documents/${summary.id}/inpaint-region`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ region, free: true }),
+      })
+      documentDetailCache.delete(summary.id)
+    })
+  },
+
   async render(
     index: number,
     options?: {

--- a/ui/lib/query/mutations.ts
+++ b/ui/lib/query/mutations.ts
@@ -270,6 +270,20 @@ export const useMaskMutations = () => {
     [queryClient],
   )
 
+  const inpaintFree = useCallback(
+    async (region: InpaintRegion, options?: { index?: number }) => {
+      const resolvedIndex =
+        options?.index ?? useEditorUiStore.getState().currentDocumentIndex
+      if (!region) return
+      await flushMaskSyncQueue()
+      await api.inpaintFree(resolvedIndex, region)
+      await invalidateCurrentDocument(queryClient, resolvedIndex)
+      await invalidateThumbnailAtIndex(queryClient, resolvedIndex)
+      useEditorUiStore.getState().setShowInpaintedImage(true)
+    },
+    [queryClient],
+  )
+
   const paintRendered = useCallback(
     async (
       patch: Uint8Array,
@@ -294,6 +308,7 @@ export const useMaskMutations = () => {
     updateMask,
     flushMaskSync,
     inpaintPartial,
+    inpaintFree,
     paintRendered,
   }
 }

--- a/ui/lib/stores/undoStore.ts
+++ b/ui/lib/stores/undoStore.ts
@@ -1,0 +1,65 @@
+'use client'
+
+import { create } from 'zustand'
+
+const MAX_HISTORY = 50
+
+export type UndoableAction = {
+  type: string
+  description?: string
+  undo: () => Promise<void> | void
+  redo: () => Promise<void> | void
+}
+
+type UndoState = {
+  past: UndoableAction[]
+  future: UndoableAction[]
+  push: (action: UndoableAction) => void
+  undo: () => Promise<void>
+  redo: () => Promise<void>
+  clear: () => void
+}
+
+export const useUndoStore = create<UndoState>((set, get) => ({
+  past: [],
+  future: [],
+
+  push: (action) => {
+    set((state) => ({
+      past: [...state.past.slice(-MAX_HISTORY + 1), action],
+      future: [],
+    }))
+  },
+
+  undo: async () => {
+    const { past, future } = get()
+    if (past.length === 0) return
+    const action = past[past.length - 1]
+    set({
+      past: past.slice(0, -1),
+      future: [action, ...future],
+    })
+    try {
+      await action.undo()
+    } catch (error) {
+      console.error('[undo] failed:', error)
+    }
+  },
+
+  redo: async () => {
+    const { past, future } = get()
+    if (future.length === 0) return
+    const action = future[0]
+    set({
+      past: [...past, action],
+      future: future.slice(1),
+    })
+    try {
+      await action.redo()
+    } catch (error) {
+      console.error('[redo] failed:', error)
+    }
+  },
+
+  clear: () => set({ past: [], future: [] }),
+}))

--- a/ui/types.d.ts
+++ b/ui/types.d.ts
@@ -70,7 +70,7 @@ export type TextBlock = {
   rendered?: Uint8Array
 }
 
-export type ToolMode = 'select' | 'block' | 'brush' | 'repairBrush' | 'eraser'
+export type ToolMode = 'select' | 'block' | 'brush' | 'repairBrush' | 'eraser' | 'magicEraser'
 
 export type InpaintRegion = {
   x: number


### PR DESCRIPTION
## Summary
- Add `free: bool` to `InpaintPartialPayload` and `InpaintRegionRequest`
- In free mode, `inpaint_partial()` skips text block requirement — LaMa inpaints purely from the mask
- Remove duplicate `/inpaint-free` endpoint, use `/inpaint-region` with `free: true`
- Frontend `inpaintFree()` calls unified endpoint
- Clear mask canvas when entering magic eraser mode
- Move undo snapshot inside inpaint queue for correct sequencing with rapid strokes

## Test plan
- [ ] Magic eraser inpaints arbitrary regions without text blocks
- [ ] Normal inpaint still requires text blocks
- [ ] Mask canvas is clean when switching to magic eraser mode
- [ ] Undo works correctly after rapid brush strokes
- [ ] `cargo test` passes