### PR TITLE
Add Ubuntu 22.04 headless CPU deployment path

### DIFF
--- a/.github/workflows/headless-cpu.yml
+++ b/.github/workflows/headless-cpu.yml
@@ -2,12 +2,31 @@ name: Headless CPU Build
 
 on:
   workflow_dispatch:
+    inputs:
+      publish_release:
+        description: Publish artifact to a GitHub Release in this fork
+        required: false
+        default: false
+        type: boolean
+      release_tag:
+        description: Release tag to create or update
+        required: false
+        default: headless-cpu-latest
+        type: string
+      release_name:
+        description: Release title
+        required: false
+        default: Koharu Headless CPU
+        type: string
   push:
     branches:
       - codex/ubuntu22-headless-cpu
 
 env:
   CARGO_TERM_COLOR: always
+
+permissions:
+  contents: write
 
 jobs:
   build-linux-cpu:
@@ -82,3 +101,21 @@ jobs:
           name: koharu-headless-cpu-ubuntu22.04
           path: koharu-headless-cpu-ubuntu22.04.tar.gz
           retention-days: 14
+
+      - name: Publish release in fork
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_release }}
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.release_tag }}
+          name: ${{ inputs.release_name }}
+          target_commitish: ${{ github.sha }}
+          prerelease: true
+          files: koharu-headless-cpu-ubuntu22.04.tar.gz
+          body: |
+            CPU-only headless build for Ubuntu 22.04.
+
+            Run:
+              ./koharu --cpu --headless --port 4000
+
+            Open:
+              http://127.0.0.1:4000/

--- a/.github/workflows/headless-cpu.yml
+++ b/.github/workflows/headless-cpu.yml
@@ -48,7 +48,7 @@ jobs:
           cache-on-failure: true
 
       - name: Cache Bun packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
@@ -77,7 +77,7 @@ jobs:
           tar -C dist -czf koharu-headless-cpu-ubuntu22.04.tar.gz .
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: koharu-headless-cpu-ubuntu22.04
           path: koharu-headless-cpu-ubuntu22.04.tar.gz

--- a/.github/workflows/headless-cpu.yml
+++ b/.github/workflows/headless-cpu.yml
@@ -83,15 +83,18 @@ jobs:
 
       - name: Prepare artifact
         run: |
-          mkdir -p dist
+          mkdir -p dist/ui
           cp target/release/koharu dist/
           cp README.md dist/README.md
+          cp -R ui/out dist/ui/
           cat > dist/RUN.txt <<'EOF'
           Run on Ubuntu 22.04:
             ./koharu --cpu --headless --port 4000
 
           Open:
             http://127.0.0.1:4000/
+
+          Keep the bundled ui/out directory next to the binary.
           EOF
           tar -C dist -czf koharu-headless-cpu-ubuntu22.04.tar.gz .
 

--- a/.github/workflows/headless-cpu.yml
+++ b/.github/workflows/headless-cpu.yml
@@ -1,0 +1,84 @@
+name: Headless CPU Build
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - codex/ubuntu22-headless-cpu
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-linux-cpu:
+    name: ubuntu-22.04 cpu
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            ca-certificates \
+            clang \
+            cmake \
+            curl \
+            file \
+            fonts-noto-cjk \
+            libayatana-appindicator3-dev \
+            libclang-dev \
+            librsvg2-dev \
+            libssl-dev \
+            libwebkit2gtk-4.1-dev \
+            libxdo-dev \
+            patchelf \
+            pkg-config \
+            wget
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - name: Cache Bun packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+
+      - name: Install JS dependencies
+        run: bun install
+
+      - name: Build static UI
+        run: bun --cwd ui build
+
+      - name: Build CPU-only binary
+        run: cargo build --release -p koharu --no-default-features
+
+      - name: Prepare artifact
+        run: |
+          mkdir -p dist
+          cp target/release/koharu dist/
+          cp README.md dist/README.md
+          cat > dist/RUN.txt <<'EOF'
+          Run on Ubuntu 22.04:
+            ./koharu --cpu --headless --port 4000
+
+          Open:
+            http://127.0.0.1:4000/
+          EOF
+          tar -C dist -czf koharu-headless-cpu-ubuntu22.04.tar.gz .
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: koharu-headless-cpu-ubuntu22.04
+          path: koharu-headless-cpu-ubuntu22.04.tar.gz
+          retention-days: 14

--- a/README.md
+++ b/README.md
@@ -213,6 +213,83 @@ The built binaries will be located in `target/release`.
 
 For platform-specific build notes, see [Build From Source](https://koharu.rs/how-to/build-from-source/). For the local development workflow, see [Contributing](https://koharu.rs/how-to/contributing/).
 
+## Ubuntu 22.04 Headless CPU
+
+If you want a reproducible Ubuntu 22.04 setup without CUDA and without the desktop window, use the helper script in this repository.
+
+### What this path does
+
+- installs the Linux system packages needed for a source build
+- installs Rust and Bun if they are missing
+- builds the static UI
+- builds the `koharu` binary in CPU-only mode
+- predownloads the default runtime and vision dependencies
+- serves the browser UI and API in headless mode
+
+### Bootstrap on Ubuntu 22.04
+
+```bash
+git clone https://github.com/mayocream/koharu.git
+cd koharu
+bash scripts/bootstrap-ubuntu22-headless-cpu.sh
+```
+
+### Start headless mode
+
+```bash
+bash scripts/run-headless-cpu.sh
+```
+
+Then open:
+
+```text
+http://127.0.0.1:4000/
+```
+
+Useful endpoints:
+
+- Web UI: `http://127.0.0.1:4000/`
+- API: `http://127.0.0.1:4000/api/v1/meta`
+- MCP: `http://127.0.0.1:4000/mcp`
+
+### Why this path exists
+
+The default Linux desktop build path in this repository follows the CUDA-enabled feature path. On Ubuntu 22.04 systems where you want a headless CPU-only deployment, the direct `cargo build --release -p koharu --no-default-features` path is more practical.
+
+Headless mode also needs access to the built `ui/out` assets. This repository includes a filesystem asset fallback so the browser UI can be served even when using the CPU-only direct Cargo build instead of the normal Tauri packaging flow.
+
+### xAI OpenAI-compatible setup
+
+Koharu's OpenAI-compatible provider expects:
+
+- base URL ending in `/v1`
+- `GET /models`
+- `POST /chat/completions`
+
+For xAI, configure **Settings -> Local LLM & OpenAI Compatible Providers** like this:
+
+- `Preset 1` or `Preset 2`
+- `Base URL`: `https://api.x.ai/v1`
+- `API Key`: your xAI API key
+- `Model name`: the exact model `id` returned by `GET /models`
+
+Example:
+
+```bash
+curl https://api.x.ai/v1/models \
+  -H "Authorization: Bearer $XAI_API_KEY"
+```
+
+### Optional systemd service
+
+Copy the provided unit file into place, then enable it:
+
+```bash
+cp deploy/koharu-headless-cpu.service /etc/systemd/system/
+systemctl daemon-reload
+systemctl enable --now koharu-headless-cpu
+```
+
 ## Sponsorship
 
 If you find Koharu useful, consider sponsoring the project to support its development.

--- a/deploy/koharu-headless-cpu.service
+++ b/deploy/koharu-headless-cpu.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Koharu Headless CPU
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/root/koharu
+Environment=PORT=4000
+ExecStart=/root/koharu/scripts/run-headless-cpu.sh
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/koharu/src/app.rs
+++ b/koharu/src/app.rs
@@ -228,8 +228,10 @@ pub async fn run() -> Result<()> {
     let shared_assets = crate::assets::share_context_assets(&mut context);
 
     if headless {
-        let resolver =
-            server::asset_resolver([crate::assets::embedded_asset_resolver(shared_assets)]);
+        let resolver = server::asset_resolver([
+            crate::assets::filesystem_asset_resolver(),
+            crate::assets::embedded_asset_resolver(shared_assets),
+        ]);
         tauri::async_runtime::spawn({
             let shared = shared.clone();
             async move {
@@ -250,6 +252,7 @@ pub async fn run() -> Result<()> {
         .append_invoke_initialization_script(format!("window.__KOHARU_API_PORT__ = {api_port};"))
         .setup(move |app| {
             let resolver = server::asset_resolver([
+                crate::assets::filesystem_asset_resolver(),
                 crate::assets::tauri_asset_resolver(app.asset_resolver()),
                 embedded_resolver,
             ]);

--- a/koharu/src/assets.rs
+++ b/koharu/src/assets.rs
@@ -80,10 +80,10 @@ pub fn embedded_asset_resolver<R: tauri::Runtime>(
 fn ui_out_roots() -> Vec<PathBuf> {
     let mut roots = Vec::new();
 
-    if let Ok(path) = env::current_exe() {
-        if let Some(parent) = path.parent() {
-            roots.push(parent.join("ui/out"));
-        }
+    if let Ok(path) = env::current_exe()
+        && let Some(parent) = path.parent()
+    {
+        roots.push(parent.join("ui/out"));
     }
 
     if let Ok(path) = env::current_dir() {

--- a/koharu/src/assets.rs
+++ b/koharu/src/assets.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, sync::Arc};
+use std::{borrow::Cow, fs, path::PathBuf, sync::Arc};
 
 use koharu_rpc::server;
 
@@ -75,6 +75,35 @@ pub fn embedded_asset_resolver<R: tauri::Runtime>(
     assets: Arc<dyn tauri::Assets<R>>,
 ) -> server::SharedAssetResolver {
     Arc::new(move |path: &str| resolve_embedded_asset(assets.as_ref(), path))
+}
+
+fn workspace_ui_out_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_WORKSPACE_DIR")).join("ui/out")
+}
+
+fn resolve_filesystem_asset(path: &str) -> Option<server::Asset> {
+    let path = path.trim_matches('/');
+    let path = if path.is_empty() { "index.html" } else { path };
+    let root = workspace_ui_out_dir();
+
+    let candidates = [
+        root.join(path),
+        root.join(format!("{path}.html")),
+        root.join(path).join("index.html"),
+    ];
+
+    candidates.into_iter().find_map(|path| {
+        let bytes = fs::read(&path).ok()?;
+        let name = path.file_name()?.to_str()?;
+        Some(server::Asset {
+            mime_type: tauri::utils::mime_type::MimeType::parse(&bytes, name),
+            bytes,
+        })
+    })
+}
+
+pub fn filesystem_asset_resolver() -> server::SharedAssetResolver {
+    Arc::new(resolve_filesystem_asset)
 }
 
 pub fn tauri_asset_resolver<R: tauri::Runtime>(

--- a/koharu/src/assets.rs
+++ b/koharu/src/assets.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, fs, path::PathBuf, sync::Arc};
+use std::{borrow::Cow, env, fs, path::PathBuf, sync::Arc};
 
 use koharu_rpc::server;
 
@@ -77,27 +77,41 @@ pub fn embedded_asset_resolver<R: tauri::Runtime>(
     Arc::new(move |path: &str| resolve_embedded_asset(assets.as_ref(), path))
 }
 
-fn workspace_ui_out_dir() -> PathBuf {
-    PathBuf::from(env!("CARGO_WORKSPACE_DIR")).join("ui/out")
+fn ui_out_roots() -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+
+    if let Ok(path) = env::current_exe() {
+        if let Some(parent) = path.parent() {
+            roots.push(parent.join("ui/out"));
+        }
+    }
+
+    if let Ok(path) = env::current_dir() {
+        roots.push(path.join("ui/out"));
+    }
+
+    roots.push(PathBuf::from(env!("CARGO_WORKSPACE_DIR")).join("ui/out"));
+    roots
 }
 
 fn resolve_filesystem_asset(path: &str) -> Option<server::Asset> {
     let path = path.trim_matches('/');
     let path = if path.is_empty() { "index.html" } else { path };
-    let root = workspace_ui_out_dir();
 
-    let candidates = [
-        root.join(path),
-        root.join(format!("{path}.html")),
-        root.join(path).join("index.html"),
-    ];
+    ui_out_roots().into_iter().find_map(|root| {
+        let candidates = [
+            root.join(path),
+            root.join(format!("{path}.html")),
+            root.join(path).join("index.html"),
+        ];
 
-    candidates.into_iter().find_map(|path| {
-        let bytes = fs::read(&path).ok()?;
-        let name = path.file_name()?.to_str()?;
-        Some(server::Asset {
-            mime_type: tauri::utils::mime_type::MimeType::parse(&bytes, name),
-            bytes,
+        candidates.into_iter().find_map(|path| {
+            let bytes = fs::read(&path).ok()?;
+            let name = path.file_name()?.to_str()?;
+            Some(server::Asset {
+                mime_type: tauri::utils::mime_type::MimeType::parse(&bytes, name),
+                bytes,
+            })
         })
     })
 }

--- a/scripts/bootstrap-ubuntu22-headless-cpu.sh
+++ b/scripts/bootstrap-ubuntu22-headless-cpu.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update
+apt-get install -y --no-install-recommends \
+  build-essential \
+  ca-certificates \
+  clang \
+  cmake \
+  curl \
+  file \
+  fonts-noto-cjk \
+  libayatana-appindicator3-dev \
+  libclang-dev \
+  librsvg2-dev \
+  libssl-dev \
+  libwebkit2gtk-4.1-dev \
+  libxdo-dev \
+  patchelf \
+  pkg-config \
+  wget
+
+if ! command -v rustup >/dev/null 2>&1; then
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+fi
+
+if ! command -v bun >/dev/null 2>&1; then
+  curl -fsSL https://bun.sh/install | bash
+fi
+
+source "$HOME/.cargo/env"
+export PATH="$HOME/.bun/bin:$PATH"
+
+bun install
+bun --cwd ui build
+cargo build --release -p koharu --no-default-features
+
+target/release/koharu --cpu --download
+
+cat <<'EOF'
+
+Build completed.
+
+Run headless UI:
+  target/release/koharu --cpu --headless --port 4000
+
+Open:
+  http://127.0.0.1:4000/
+
+EOF

--- a/scripts/run-headless-cpu.sh
+++ b/scripts/run-headless-cpu.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [ ! -x "$ROOT/target/release/koharu" ]; then
+  echo "Binary not found: $ROOT/target/release/koharu" >&2
+  echo "Build first with scripts/bootstrap-ubuntu22-headless-cpu.sh" >&2
+  exit 1
+fi
+
+PORT="${PORT:-4000}"
+
+exec "$ROOT/target/release/koharu" --cpu --headless --port "$PORT"


### PR DESCRIPTION
## Summary

  This PR adds a practical CPU-only deployment path for Ubuntu 22.04 headless usage.

  ## Changes

  - add a filesystem asset fallback so headless mode can serve the browser UI when using the direct CPU-only Cargo build
  - add `scripts/bootstrap-ubuntu22-headless-cpu.sh` to install dependencies, build the UI, build `koharu` in CPU-only mode, and prefetch runtime assets
  - add `scripts/run-headless-cpu.sh` as a simple launcher for `--cpu --headless`
  - add `deploy/koharu-headless-cpu.service` for optional systemd deployment
  - document the Ubuntu 22.04 headless CPU workflow and xAI OpenAI-compatible provider setup in `README.md`

  ## Why

  The default Linux desktop build path follows the CUDA-enabled feature path. On Ubuntu 22.04 systems where a headless CPU-only deployment is preferred, a direct `cargo build --release -p koharu --no-default-
  features` flow is more practical.

  However, that direct build path does not embed the Tauri frontend assets the same way as the normal packaging flow, so the browser UI in headless mode is not served unless the runtime can fall back to `ui/
  out` from the filesystem.

  ## Notes

  - this PR does not add built binaries to the repository
  - the new path is intended to make reproduction on another VM straightforward using the provided scripts
  - verified locally on Ubuntu 22.04 with `--cpu --headless --port 4000`, including browser UI at `/`, API at `/api/v1/meta`, and MCP at `/mcp`