### PR TITLE
feat: implementing --host cli parameter

### DIFF
--- a/koharu/src/app.rs
+++ b/koharu/src/app.rs
@@ -21,7 +21,10 @@ struct Cli {
     cpu: bool,
     #[arg(short, long, value_name = "PORT", help = "Bind to a specific port")]
     port: Option<u16>,
-    #[arg(long,help = "Bind the HTTP service to a specific host instead of 127.0.0.1")]
+    #[arg(
+        long,
+        help = "Bind the HTTP service to a specific host instead of 127.0.0.1"
+    )]
     host: Option<String>,
     #[arg(long, help = "Run without GUI")]
     headless: bool,


### PR DESCRIPTION
Implementing basic `--host` flag to be able to change host. 

It uses only long version, because short version conflict with help.\

Closes #313 