### PR TITLE
fix: persist font selection to document default when block is selected

### DIFF
--- a/ui/components/panels/RenderControlsPanel.tsx
+++ b/ui/components/panels/RenderControlsPanel.tsx
@@ -410,8 +410,7 @@ export function RenderControlsPanel() {
                   value,
                   selectedBlock?.style?.fontFamilies,
                 )
-                if (applyStyleToSelected({ fontFamilies: nextFamilies })) return
-                // Set as document default font
+                // Always update document default font when font changes
                 if (documentId) {
                   void updateDocumentStyle(documentId, {
                     defaultFont: value,
@@ -421,6 +420,7 @@ export function RenderControlsPanel() {
                     }),
                   )
                 }
+                if (applyStyleToSelected({ fontFamilies: nextFamilies })) return
               }}
             />
           </div>


### PR DESCRIPTION
When a user selects a font while a text block is selected, the font should also be saved as the document's default font. This ensures that new panels/blocks will use the same font instead of reverting to the system default (BANGERS).

## Problem
When users selected a font with a text block selected, the font was only applied to that specific block. The document's default font was never updated, so when navigating to a new panel, the font would revert to the system default (BANGERS).

## Solution
Always update the document's default font when the font selection changes, regardless of whether a block is selected. This ensures the selected font becomes the new global default for the document.

Fixes #344