### PR TITLE
feat: change sort_manga_read_order algorithm for better ordering

### DIFF
--- a/koharu-app/src/engine.rs
+++ b/koharu-app/src/engine.rs
@@ -1097,11 +1097,11 @@ fn sort_manga_reading_order(blocks: &mut [TextBlock]) {
         return;
     }
 
-    // Determine dynamic gap thresholds by calculating the median dimensions 
+    // Determine dynamic gap thresholds by calculating the median dimensions
     // of all text blocks on the page.
     let mut widths: Vec<f32> = blocks.iter().map(|b| b.width).collect();
     let mut heights: Vec<f32> = blocks.iter().map(|b| b.height).collect();
-    
+
     widths.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
     heights.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
 
@@ -1121,16 +1121,17 @@ fn sort_manga_reading_order(blocks: &mut [TextBlock]) {
         }
 
         let cut_result = find_best_cut(blocks, min_gap_x, min_gap_y);
-        
+
         let Some((best_axis, best_gap)) = cut_result else {
             // FALLBACK: Row-Aware sort for clusters that can't be cleanly cut.
-            let row_height = min_gap_y * 4.0; 
+            let row_height = min_gap_y * 4.0;
 
             blocks.sort_by(|a, b| {
                 let row_a = (a.y / row_height).floor();
                 let row_b = (b.y / row_height).floor();
 
-                row_a.partial_cmp(&row_b)
+                row_a
+                    .partial_cmp(&row_b)
                     .unwrap_or(std::cmp::Ordering::Equal)
                     .then_with(|| b.x.partial_cmp(&a.x).unwrap_or(std::cmp::Ordering::Equal))
             });
@@ -1140,8 +1141,8 @@ fn sort_manga_reading_order(blocks: &mut [TextBlock]) {
         let cut_coord = (best_gap.0 + best_gap.1) / 2.0;
 
         // In-place stable partition to avoid recursively allocating new vectors.
-        // Rust's `bool` sorts `false` before `true`. By mapping items destined 
-        // for the primary partition (Right or Top) to `false`, we separate 
+        // Rust's `bool` sorts `false` before `true`. By mapping items destined
+        // for the primary partition (Right or Top) to `false`, we separate
         // the geometry cleanly into two contiguous segments.
         blocks.sort_by_key(|block| {
             if best_axis == Axis::X {
@@ -1152,13 +1153,16 @@ fn sort_manga_reading_order(blocks: &mut [TextBlock]) {
         });
 
         // Find where the split boundary lies
-        let group1_len = blocks.iter().filter(|block| {
-            if best_axis == Axis::X {
-                (block.x + block.width * 0.5) >= cut_coord
-            } else {
-                (block.y + block.height * 0.5) <= cut_coord
-            }
-        }).count();
+        let group1_len = blocks
+            .iter()
+            .filter(|block| {
+                if best_axis == Axis::X {
+                    (block.x + block.width * 0.5) >= cut_coord
+                } else {
+                    (block.y + block.height * 0.5) <= cut_coord
+                }
+            })
+            .count();
 
         if group1_len == 0 || group1_len == blocks.len() {
             blocks.sort_by(|a, b| b.x.partial_cmp(&a.x).unwrap_or(std::cmp::Ordering::Equal));
@@ -1171,9 +1175,15 @@ fn sort_manga_reading_order(blocks: &mut [TextBlock]) {
         xy_cut_recursive(right, min_gap_x, min_gap_y);
     }
 
-    fn find_best_cut(blocks: &[TextBlock], min_gap_x: f32, min_gap_y: f32) -> Option<(Axis, (f32, f32))> {
-        let mut x_intervals: Vec<(f32, f32)> = blocks.iter().map(|b| (b.x, b.x + b.width)).collect();
-        let mut y_intervals: Vec<(f32, f32)> = blocks.iter().map(|b| (b.y, b.y + b.height)).collect();
+    fn find_best_cut(
+        blocks: &[TextBlock],
+        min_gap_x: f32,
+        min_gap_y: f32,
+    ) -> Option<(Axis, (f32, f32))> {
+        let mut x_intervals: Vec<(f32, f32)> =
+            blocks.iter().map(|b| (b.x, b.x + b.width)).collect();
+        let mut y_intervals: Vec<(f32, f32)> =
+            blocks.iter().map(|b| (b.y, b.y + b.height)).collect();
 
         x_intervals.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
         y_intervals.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
@@ -1201,13 +1211,15 @@ fn sort_manga_reading_order(blocks: &mut [TextBlock]) {
     }
 
     fn find_largest_gap(intervals: &[(f32, f32)], min_gap: f32) -> Option<(f32, f32)> {
-        if intervals.is_empty() { return None; }
+        if intervals.is_empty() {
+            return None;
+        }
 
         let mut largest_gap: Option<(f32, f32)> = None;
         let mut current_max_end = intervals[0].1;
 
         for interval in intervals.iter().skip(1) {
-            // A valid separation exists if the start of the current interval 
+            // A valid separation exists if the start of the current interval
             // does not intersect the bounding maximum of all preceding intervals.
             if interval.0 > current_max_end {
                 let gap_size = interval.0 - current_max_end;


### PR DESCRIPTION
## Summary
Changed sort_manga_read_order from naive top-down, right-left ordering to recursive XY-cut algorithm, as previous implementation inaccurately represented reading order of text blocks in tested manga panels. 

The new algorithm essentially finds the largest spatial clusters of text blocks and slices the page at the widest whitespace gaps, with priority towards horizontal cuts to identify separate "panels" until each block is isolated, which then orders the blocks in the order they were sliced top-down, right-left.

## Examples
| Old Algorithm | New Algorithm |
| --- | --- |
| ![before1](https://github.com/user-attachments/assets/97d02aee-18e3-4ce4-885b-895514559310) | ![after1](https://github.com/user-attachments/assets/9c390803-1889-4c16-99a6-d939df26ccb7) |
| ![before2](https://github.com/user-attachments/assets/3625d3fb-7ebd-4219-b699-76e47dbca983) | ![after2](https://github.com/user-attachments/assets/cb6c3f86-b3e1-400c-98f2-c0f658026fd4) |
| ![before3](https://github.com/user-attachments/assets/db41e1a3-3f3e-49f8-97b2-b8eef9673641) | ![after3](https://github.com/user-attachments/assets/64da136a-d633-4631-a13d-40aa6bc26379) |
| ![before4](https://github.com/user-attachments/assets/7fad729b-87d8-4ccc-9607-85460fa3848b) | ![after4](https://github.com/user-attachments/assets/92ade7d2-b0bd-416f-bfbd-c1c78c031fa4) |







