### PR TITLE
fix: add `get_document_id_for_index` mcp tool

### DIFF
--- a/koharu-core/src/commands.rs
+++ b/koharu-core/src/commands.rs
@@ -122,6 +122,12 @@ pub struct DocumentIdParam {
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
+pub struct DocumentIndexParam {
+    pub index: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct ProcessParams {
     pub document_id: Option<String>,
     pub llm_target: Option<crate::LlmTarget>,

--- a/koharu-rpc/src/mcp/mod.rs
+++ b/koharu-rpc/src/mcp/mod.rs
@@ -15,10 +15,10 @@ use tokio::sync::RwLock;
 
 use koharu_app::{AppResources, edit, engine, io, llm, pipeline};
 use koharu_core::commands::{
-    AddTextBlockPayload, DocumentIdParam, ExportDocumentParams, FileEntry, InpaintRegionParams,
-    LlmGenerateParams, LlmLoadParams, MaskMorphPayload, OpenDocumentsParams, OpenDocumentsPayload,
-    ProcessParams, ProcessRequest, RemoveTextBlockPayload, RenderParams, UpdateTextBlockPayload,
-    ViewImageParams, ViewTextBlockParams,
+    AddTextBlockPayload, DocumentIdParam, DocumentIndexParam, ExportDocumentParams, FileEntry,
+    InpaintRegionParams, LlmGenerateParams, LlmLoadParams, MaskMorphPayload, OpenDocumentsParams,
+    OpenDocumentsPayload, ProcessParams, ProcessRequest, RemoveTextBlockPayload, RenderParams,
+    UpdateTextBlockPayload, ViewImageParams, ViewTextBlockParams,
 };
 use koharu_core::views::to_doc_info;
 use koharu_core::{LlmLoadRequest, PipelineLlmRequest, Region};
@@ -589,6 +589,16 @@ impl KoharuMcp {
             "Inpainted region ({},{}) {}x{}",
             p.x, p.y, p.width, p.height
         ))
+    }
+
+    #[tool(description = "Get the document ID for the document at index")]
+    async fn get_document_id_for_index(
+        &self,
+        Parameters(p): Parameters<DocumentIndexParam>,
+    ) -> Result<String, String> {
+        let res = self.resources()?;
+        let document_id = self.document_id_for_index(&res, p.index).await?;
+        Ok(document_id)
     }
 }
 


### PR DESCRIPTION
Add a new `get_document_id_for_index` mcp tool, returning `documentId` of a document at `index`.