### PR TITLE
feat: Tool keybind and Brush Outline on canvas implementation

### DIFF
--- a/ui/components/canvas/ToolRail.tsx
+++ b/ui/components/canvas/ToolRail.tsx
@@ -69,6 +69,7 @@ const MODES: ModeDefinition[] = [
 export function ToolRail() {
   const mode = useEditorUiStore((state) => state.mode)
   const setMode = useEditorUiStore((state) => state.setMode)
+  const shortcuts = usePreferencesStore((state) => state.shortcuts)
   const { t } = useTranslation()
 
   return (
@@ -106,7 +107,9 @@ export function ToolRail() {
                 </Button>
               </TooltipTrigger>
               <TooltipContent side='right' sideOffset={8}>
-                {label}
+                {shortcuts[item.value as keyof typeof shortcuts]
+                  ? `${label} (${shortcuts[item.value as keyof typeof shortcuts].toUpperCase()})`
+                  : label}
               </TooltipContent>
             </Tooltip>
           )
@@ -129,6 +132,7 @@ function BrushToolWithPopover({
 }) {
   const {
     brushConfig: { size: brushSize, color: brushColor },
+    shortcuts,
     setBrushConfig,
   } = usePreferencesStore()
   const { t } = useTranslation()
@@ -152,7 +156,9 @@ function BrushToolWithPopover({
           </PopoverTrigger>
         </TooltipTrigger>
         <TooltipContent side='right' sideOffset={8}>
-          {label}
+          {shortcuts[item.value as keyof typeof shortcuts]
+            ? `${label} (${shortcuts[item.value as keyof typeof shortcuts].toUpperCase()})`
+            : label}
         </TooltipContent>
       </Tooltip>
       <PopoverContent side='right' align='start' className='w-56'>
@@ -173,9 +179,17 @@ function BrushToolWithPopover({
                   setBrushConfig({ size: vals[0] ?? brushSize })
                 }
               />
-              <span className='text-muted-foreground w-10 text-right tabular-nums'>
-                {brushSize}px
-              </span>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className='text-muted-foreground w-10 cursor-help text-right tabular-nums'>
+                    {brushSize}px
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side='bottom'>
+                  {t('toolbar.brushSize')} ({shortcuts.decreaseBrushSize}{' '}
+                  {shortcuts.increaseBrushSize})
+                </TooltipContent>
+              </Tooltip>
             </div>
           </div>
           <div className='space-y-2'>

--- a/ui/components/canvas/Workspace.tsx
+++ b/ui/components/canvas/Workspace.tsx
@@ -29,8 +29,9 @@ import { useTextBlocks, useDocumentLayer } from '@/hooks/useTextBlocks'
 import { useMaskDrawing } from '@/hooks/useMaskDrawing'
 import { useRenderBrushDrawing } from '@/hooks/useRenderBrushDrawing'
 import { useBrushLayerDisplay } from '@/hooks/useBrushLayerDisplay'
+import { useBrushCursor } from '@/hooks/useBrushCursor'
+import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts'
 import { useEditorUiStore } from '@/lib/stores/editorUiStore'
-import { usePreferencesStore } from '@/lib/stores/preferencesStore'
 import {
   resolvePinchMemoScaleRatio,
   resolvePinchNextScaleRatio,
@@ -38,89 +39,8 @@ import {
 
 const BRUSH_CURSOR = 'none'
 
-function useBrushCursor(
-  canvasRef: React.RefObject<HTMLDivElement | null>,
-  mode: string,
-  scaleRatio: number,
-  currentDocumentId?: string,
-) {
-  const brushCursorRef = useRef<HTMLDivElement>(null)
-  const cachedRectRef = useRef<DOMRect | null>(null)
-  const mousePosRef = useRef<{ x: number; y: number } | null>(null)
-  const brushSize = usePreferencesStore((state) => state.brushConfig.size)
-
-  const isBrushMode = useMemo(
-    () => mode === 'brush' || mode === 'repairBrush' || mode === 'eraser',
-    [mode],
-  )
-
-  useEffect(() => {
-    cachedRectRef.current = null
-    const canvas = canvasRef.current
-    const cursor = brushCursorRef.current
-    if (!canvas || !cursor) return
-
-    if (!isBrushMode) {
-      cursor.style.opacity = '0'
-      return
-    }
-
-    const updatePos = (clientX: number, clientY: number) => {
-      const rect = cachedRectRef.current || canvas.getBoundingClientRect()
-      if (!cachedRectRef.current) cachedRectRef.current = rect
-      const x = clientX - rect.left
-      const y = clientY - rect.top
-      cursor.style.transform = `translate(${x}px, ${y}px) translate(-50%, -50%)`
-    }
-
-    const refresh = () => {
-      cachedRectRef.current = canvas.getBoundingClientRect()
-      if (mousePosRef.current) {
-        updatePos(mousePosRef.current.x, mousePosRef.current.y)
-      }
-    }
-
-    const handleMove = (e: PointerEvent) => {
-      mousePosRef.current = { x: e.clientX, y: e.clientY }
-      updatePos(e.clientX, e.clientY)
-    }
-
-    const handleEnter = () => {
-      refresh()
-      cursor.style.opacity = '1'
-    }
-
-    const handleLeave = () => {
-      cursor.style.opacity = '0'
-    }
-
-    const resizeObserver = new ResizeObserver(() => {
-      refresh()
-    })
-    resizeObserver.observe(canvas)
-
-    canvas.addEventListener('pointermove', handleMove)
-    canvas.addEventListener('pointerenter', handleEnter)
-    canvas.addEventListener('pointerleave', handleLeave)
-    window.addEventListener('scroll', refresh, true)
-    window.addEventListener('resize', refresh)
-
-    refresh()
-
-    return () => {
-      resizeObserver.disconnect()
-      canvas.removeEventListener('pointermove', handleMove)
-      canvas.removeEventListener('pointerenter', handleEnter)
-      canvas.removeEventListener('pointerleave', handleLeave)
-      window.removeEventListener('scroll', refresh, true)
-      window.removeEventListener('resize', refresh)
-    }
-  }, [isBrushMode, currentDocumentId])
-
-  return { brushCursorRef, isBrushMode, brushSize }
-}
-
 export function Workspace() {
+  useKeyboardShortcuts()
   const scale = useEditorUiStore((state) => state.scale)
   const showSegmentationMask = useEditorUiStore(
     (state) => state.showSegmentationMask,
@@ -198,7 +118,6 @@ export function Workspace() {
   const { brushCursorRef, isBrushMode, brushSize } = useBrushCursor(
     canvasRef,
     mode,
-    scaleRatio,
     currentDocument?.id,
   )
 

--- a/ui/components/canvas/Workspace.tsx
+++ b/ui/components/canvas/Workspace.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useMemo, useCallback } from 'react'
 import type React from 'react'
 import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area'
 import { useGesture } from '@use-gesture/react'
@@ -30,13 +30,93 @@ import { useMaskDrawing } from '@/hooks/useMaskDrawing'
 import { useRenderBrushDrawing } from '@/hooks/useRenderBrushDrawing'
 import { useBrushLayerDisplay } from '@/hooks/useBrushLayerDisplay'
 import { useEditorUiStore } from '@/lib/stores/editorUiStore'
+import { usePreferencesStore } from '@/lib/stores/preferencesStore'
 import {
   resolvePinchMemoScaleRatio,
   resolvePinchNextScaleRatio,
 } from '@/components/canvas/zoomGestures'
 
-const BRUSH_CURSOR =
-  'url(\'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="16" height="16"%3E%3Ccircle cx="8" cy="8" r="4" stroke="black" stroke-width="1.5" fill="white"/%3E%3C/svg%3E\') 8 8, crosshair'
+const BRUSH_CURSOR = 'none'
+
+function useBrushCursor(
+  canvasRef: React.RefObject<HTMLDivElement | null>,
+  mode: string,
+  scaleRatio: number,
+  currentDocumentId?: string,
+) {
+  const brushCursorRef = useRef<HTMLDivElement>(null)
+  const cachedRectRef = useRef<DOMRect | null>(null)
+  const mousePosRef = useRef<{ x: number; y: number } | null>(null)
+  const brushSize = usePreferencesStore((state) => state.brushConfig.size)
+
+  const isBrushMode = useMemo(
+    () => mode === 'brush' || mode === 'repairBrush' || mode === 'eraser',
+    [mode],
+  )
+
+  useEffect(() => {
+    cachedRectRef.current = null
+    const canvas = canvasRef.current
+    const cursor = brushCursorRef.current
+    if (!canvas || !cursor) return
+
+    if (!isBrushMode) {
+      cursor.style.opacity = '0'
+      return
+    }
+
+    const updatePos = (clientX: number, clientY: number) => {
+      const rect = cachedRectRef.current || canvas.getBoundingClientRect()
+      if (!cachedRectRef.current) cachedRectRef.current = rect
+      const x = clientX - rect.left
+      const y = clientY - rect.top
+      cursor.style.transform = `translate(${x}px, ${y}px) translate(-50%, -50%)`
+    }
+
+    const refresh = () => {
+      cachedRectRef.current = canvas.getBoundingClientRect()
+      if (mousePosRef.current) {
+        updatePos(mousePosRef.current.x, mousePosRef.current.y)
+      }
+    }
+
+    const handleMove = (e: PointerEvent) => {
+      mousePosRef.current = { x: e.clientX, y: e.clientY }
+      updatePos(e.clientX, e.clientY)
+    }
+
+    const handleEnter = () => {
+      refresh()
+      cursor.style.opacity = '1'
+    }
+
+    const handleLeave = () => {
+      cursor.style.opacity = '0'
+    }
+
+    const resizeObserver = new ResizeObserver(() => {
+      refresh()
+    })
+    resizeObserver.observe(canvas)
+
+    canvas.addEventListener('pointermove', handleMove)
+    canvas.addEventListener('pointerenter', handleEnter)
+    canvas.addEventListener('pointerleave', handleLeave)
+    window.addEventListener('scroll', refresh, true)
+    window.addEventListener('resize', refresh)
+
+    return () => {
+      resizeObserver.disconnect()
+      canvas.removeEventListener('pointermove', handleMove)
+      canvas.removeEventListener('pointerenter', handleEnter)
+      canvas.removeEventListener('pointerleave', handleLeave)
+      window.removeEventListener('scroll', refresh, true)
+      window.removeEventListener('resize', refresh)
+    }
+  }, [isBrushMode, currentDocumentId, scaleRatio])
+
+  return { brushCursorRef, isBrushMode, brushSize }
+}
 
 export function Workspace() {
   const scale = useEditorUiStore((state) => state.scale)
@@ -98,6 +178,10 @@ export function Workspace() {
   const { setScale: applyScale } = useCanvasZoom()
   const scaleRatio = scale / 100
   const canvasRef = useRef<HTMLDivElement | null>(null)
+  const handleViewportRef = useCallback((el: HTMLDivElement | null) => {
+    viewportRef.current = el
+    if (el) setCanvasViewport(el)
+  }, [])
   const pointerToDocument = usePointerToDocument(scaleRatio, canvasRef)
   const { draftBlock, bind: bindBlockDraft } = useBlockDrafting({
     mode,
@@ -108,12 +192,26 @@ export function Workspace() {
       void appendBlock(block)
     },
   })
-  const maskPointerEnabled =
-    mode === 'repairBrush' ||
-    (mode === 'eraser' && (showSegmentationMask || !showBrushLayer))
-  const brushPointerEnabled =
-    mode === 'brush' ||
-    (mode === 'eraser' && !showSegmentationMask && showBrushLayer)
+
+  const { brushCursorRef, isBrushMode, brushSize } = useBrushCursor(
+    canvasRef,
+    mode,
+    scaleRatio,
+    currentDocument?.id,
+  )
+
+  const maskPointerEnabled = useMemo(
+    () =>
+      mode === 'repairBrush' ||
+      (mode === 'eraser' && (showSegmentationMask || !showBrushLayer)),
+    [mode, showSegmentationMask, showBrushLayer],
+  )
+  const brushPointerEnabled = useMemo(
+    () =>
+      mode === 'brush' ||
+      (mode === 'eraser' && !showSegmentationMask && showBrushLayer),
+    [mode, showSegmentationMask, showBrushLayer],
+  )
   const maskDrawing = useMaskDrawing({
     mode,
     currentDocument,
@@ -265,20 +363,21 @@ export function Workspace() {
     handleContextMenu(event)
   }
 
-  const isBrushMode =
-    mode === 'brush' || mode === 'repairBrush' || mode === 'eraser'
-  const canvasCursor = isBrushMode
-    ? BRUSH_CURSOR
-    : mode === 'block'
-      ? 'cell'
-      : 'default'
+  const canvasCursor = useMemo(
+    () => (isBrushMode ? BRUSH_CURSOR : mode === 'block' ? 'cell' : 'default'),
+    [isBrushMode, mode],
+  )
 
-  const canvasDimensions = currentDocument
-    ? {
-        width: currentDocument.width * scaleRatio,
-        height: currentDocument.height * scaleRatio,
-      }
-    : { width: 0, height: 0 }
+  const canvasDimensions = useMemo(
+    () =>
+      currentDocument
+        ? {
+            width: currentDocument.width * scaleRatio,
+            height: currentDocument.height * scaleRatio,
+          }
+        : { width: 0, height: 0 },
+    [currentDocument?.width, currentDocument?.height, scaleRatio],
+  )
 
   return (
     <div className='bg-muted flex min-h-0 min-w-0 flex-1'>
@@ -287,10 +386,7 @@ export function Workspace() {
         <CanvasToolbar />
         <ScrollAreaPrimitive.Root className='flex min-h-0 min-w-0 flex-1'>
           <ScrollAreaPrimitive.Viewport
-            ref={(el) => {
-              viewportRef.current = el
-              setCanvasViewport(el)
-            }}
+            ref={handleViewportRef}
             data-testid='workspace-viewport'
             className='grid size-full place-content-center-safe'
           >
@@ -317,6 +413,15 @@ export function Workspace() {
                       onContextMenuCapture={handleCanvasContextMenu}
                       {...blockDraftBindings}
                     >
+                      <div
+                        ref={brushCursorRef}
+                        className='pointer-events-none absolute z-50 rounded-full border border-white shadow-[0_0_0_1px_rgba(0,0,0,0.5),0_1px_3px_rgba(0,0,0,0.3)] transition-opacity duration-75'
+                        style={{
+                          opacity: 0,
+                          width: brushSize * scaleRatio,
+                          height: brushSize * scaleRatio,
+                        }}
+                      />
                       <div className='absolute inset-0'>
                         <Image
                           data={imageData}

--- a/ui/components/canvas/Workspace.tsx
+++ b/ui/components/canvas/Workspace.tsx
@@ -105,6 +105,8 @@ function useBrushCursor(
     window.addEventListener('scroll', refresh, true)
     window.addEventListener('resize', refresh)
 
+    refresh()
+
     return () => {
       resizeObserver.disconnect()
       canvas.removeEventListener('pointermove', handleMove)
@@ -113,7 +115,7 @@ function useBrushCursor(
       window.removeEventListener('scroll', refresh, true)
       window.removeEventListener('resize', refresh)
     }
-  }, [isBrushMode, currentDocumentId, scaleRatio])
+  }, [isBrushMode, currentDocumentId])
 
   return { brushCursorRef, isBrushMode, brushSize }
 }
@@ -180,7 +182,7 @@ export function Workspace() {
   const canvasRef = useRef<HTMLDivElement | null>(null)
   const handleViewportRef = useCallback((el: HTMLDivElement | null) => {
     viewportRef.current = el
-    if (el) setCanvasViewport(el)
+    setCanvasViewport(el)
   }, [])
   const pointerToDocument = usePointerToDocument(scaleRatio, canvasRef)
   const { draftBlock, bind: bindBlockDraft } = useBlockDrafting({

--- a/ui/hooks/useBrushCursor.ts
+++ b/ui/hooks/useBrushCursor.ts
@@ -1,0 +1,105 @@
+'use client'
+
+import { useEffect, useRef, useMemo } from 'react'
+import type React from 'react'
+import { usePreferencesStore } from '@/lib/stores/preferencesStore'
+
+export function useBrushCursor(
+  canvasRef: React.RefObject<HTMLDivElement | null>,
+  mode: string,
+  currentDocumentId?: string,
+) {
+  const brushCursorRef = useRef<HTMLDivElement>(null)
+  const cachedRectRef = useRef<DOMRect | null>(null)
+  const mousePosRef = useRef<{ x: number; y: number } | null>(null)
+  const isInsideRef = useRef(false)
+  const brushSize = usePreferencesStore((state) => state.brushConfig.size)
+
+  const isBrushMode = useMemo(
+    () => mode === 'brush' || mode === 'repairBrush' || mode === 'eraser',
+    [mode],
+  )
+
+  const isBrushModeRef = useRef(isBrushMode)
+  useEffect(() => {
+    isBrushModeRef.current = isBrushMode
+  }, [isBrushMode])
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+
+    const refresh = () => {
+      cachedRectRef.current = canvas.getBoundingClientRect()
+      if (mousePosRef.current) {
+        updateCursorPosition(mousePosRef.current.x, mousePosRef.current.y)
+      }
+    }
+
+    const updateCursorPosition = (clientX: number, clientY: number) => {
+      if (!brushCursorRef.current) return
+      const rect = cachedRectRef.current || canvas.getBoundingClientRect()
+      if (!cachedRectRef.current) cachedRectRef.current = rect
+      const x = clientX - rect.left
+      const y = clientY - rect.top
+      brushCursorRef.current.style.transform = `translate(${x}px, ${y}px) translate(-50%, -50%)`
+    }
+
+    const handleMove = (e: PointerEvent) => {
+      mousePosRef.current = { x: e.clientX, y: e.clientY }
+      updateCursorPosition(e.clientX, e.clientY)
+    }
+
+    const handleEnter = () => {
+      isInsideRef.current = true
+      refresh()
+      if (isBrushModeRef.current && brushCursorRef.current) {
+        brushCursorRef.current.style.opacity = '1'
+      }
+    }
+
+    const handleLeave = () => {
+      isInsideRef.current = false
+      if (brushCursorRef.current) {
+        brushCursorRef.current.style.opacity = '0'
+      }
+    }
+
+    const resizeObserver = new ResizeObserver(() => refresh())
+    resizeObserver.observe(canvas)
+
+    canvas.addEventListener('pointermove', handleMove)
+    canvas.addEventListener('pointerenter', handleEnter)
+    canvas.addEventListener('pointerleave', handleLeave)
+    window.addEventListener('scroll', refresh, true)
+    window.addEventListener('resize', refresh)
+
+    // Initial positioning if we already have a mouse position
+    if (mousePosRef.current) {
+      updateCursorPosition(mousePosRef.current.x, mousePosRef.current.y)
+    }
+
+    return () => {
+      resizeObserver.disconnect()
+      canvas.removeEventListener('pointermove', handleMove)
+      canvas.removeEventListener('pointerenter', handleEnter)
+      canvas.removeEventListener('pointerleave', handleLeave)
+      window.removeEventListener('scroll', refresh, true)
+      window.removeEventListener('resize', refresh)
+    }
+  }, [canvasRef, currentDocumentId])
+
+  // Separate effect for visibility to avoid re-attaching listeners
+  useEffect(() => {
+    const cursor = brushCursorRef.current
+    if (!cursor) return
+
+    if (isBrushMode && isInsideRef.current) {
+      cursor.style.opacity = '1'
+    } else {
+      cursor.style.opacity = '0'
+    }
+  }, [isBrushMode])
+
+  return { brushCursorRef, isBrushMode, brushSize }
+}

--- a/ui/hooks/useKeyboardShortcuts.ts
+++ b/ui/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,52 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useEditorUiStore } from '@/lib/stores/editorUiStore'
+import { usePreferencesStore } from '@/lib/stores/preferencesStore'
+
+export function useKeyboardShortcuts() {
+  const setMode = useEditorUiStore((state) => state.setMode)
+  const setBrushConfig = usePreferencesStore((state) => state.setBrushConfig)
+  const shortcuts = usePreferencesStore((state) => state.shortcuts)
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      // Skip if user is typing in an input
+      const target = event.target as HTMLElement
+      if (
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.isContentEditable
+      ) {
+        return
+      }
+
+      const key = event.key.toLowerCase()
+
+      // Tool Switching
+      if (key === shortcuts.select) {
+        setMode('select')
+      } else if (key === shortcuts.block) {
+        setMode('block')
+      } else if (key === shortcuts.brush) {
+        setMode('brush')
+      } else if (key === shortcuts.eraser) {
+        setMode('eraser')
+      } else if (key === shortcuts.repairBrush) {
+        setMode('repairBrush')
+      }
+
+      // Brush Size
+      else if (key === shortcuts.increaseBrushSize) {
+        const currentSize = usePreferencesStore.getState().brushConfig.size
+        setBrushConfig({ size: Math.min(128, currentSize + 4) })
+      } else if (key === shortcuts.decreaseBrushSize) {
+        const currentSize = usePreferencesStore.getState().brushConfig.size
+        setBrushConfig({ size: Math.max(8, currentSize - 4) })
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [setMode, setBrushConfig, shortcuts])
+}

--- a/ui/lib/stores/preferencesStore.ts
+++ b/ui/lib/stores/preferencesStore.ts
@@ -13,6 +13,16 @@ type PreferencesState = {
   setDefaultFont: (font?: string) => void
   customSystemPrompt?: string
   setCustomSystemPrompt: (prompt?: string) => void
+  shortcuts: {
+    select: string
+    block: string
+    brush: string
+    eraser: string
+    repairBrush: string
+    increaseBrushSize: string
+    decreaseBrushSize: string
+  }
+  setShortcuts: (shortcuts: Partial<PreferencesState['shortcuts']>) => void
   resetPreferences: () => void
 }
 
@@ -20,6 +30,15 @@ const initialPreferences = {
   brushConfig: {
     size: 36,
     color: '#ffffff',
+  },
+  shortcuts: {
+    select: 'v',
+    block: 'm',
+    brush: 'b',
+    eraser: 'e',
+    repairBrush: 'r',
+    increaseBrushSize: ']',
+    decreaseBrushSize: '[',
   },
 }
 
@@ -36,6 +55,13 @@ export const usePreferencesStore = create<PreferencesState>()(
         })),
       setDefaultFont: (font) => set({ defaultFont: font }),
       setCustomSystemPrompt: (prompt) => set({ customSystemPrompt: prompt }),
+      setShortcuts: (shortcuts) =>
+        set((state) => ({
+          shortcuts: {
+            ...state.shortcuts,
+            ...shortcuts,
+          },
+        })),
       resetPreferences: () => set({ ...initialPreferences }),
     }),
     {
@@ -57,6 +83,7 @@ export const usePreferencesStore = create<PreferencesState>()(
         brushConfig: state.brushConfig,
         defaultFont: state.defaultFont,
         customSystemPrompt: state.customSystemPrompt,
+        shortcuts: state.shortcuts,
       }),
     },
   ),


### PR DESCRIPTION
## Summary
Implemented a simple brush outline that scales according to brush px size selection and zoom on image. This outline does not show if the appropriate mode selections are no selected, and only while the cursor is within the area of the canvas.


https://github.com/user-attachments/assets/e3e6807c-3f35-49b8-8fd1-ea7e136a01a8



