### PR TITLE
feat(ui): add model search to llm popover

### DIFF
--- a/e2e/helpers/pipeline.ts
+++ b/e2e/helpers/pipeline.ts
@@ -49,6 +49,15 @@ export async function openLlmPopover(page: Page) {
 }
 
 async function assertLlmModelOptions(page: Page) {
+  await page
+    .getByTestId(selectors.llm.modelSearch)
+    .fill('___definitely_not_a_model___')
+  await page.getByTestId(selectors.llm.modelSelect).click()
+  await expect(page.getByTestId(selectors.llm.modelEmpty)).toBeVisible({
+    timeout: 30_000,
+  })
+  await page.keyboard.press('Escape')
+  await page.getByTestId(selectors.llm.modelSearch).fill('')
   await page.getByTestId(selectors.llm.modelSelect).click()
   const firstOption = page.getByTestId(selectors.llm.modelOption(0))
   await expect(firstOption).toBeVisible({ timeout: 60_000 })
@@ -96,7 +105,9 @@ export async function generateTranslationForBlock(
   blockIndex = 0,
   timeout = 45_000,
 ) {
-  const field = page.getByTestId(selectors.panels.textBlockTranslation(blockIndex))
+  const field = page.getByTestId(
+    selectors.panels.textBlockTranslation(blockIndex),
+  )
   const previous = await field.inputValue()
   await page.getByTestId(selectors.panels.textBlockGenerate(blockIndex)).click()
 
@@ -114,7 +125,11 @@ export async function startProcessCurrent(page: Page) {
 }
 
 export async function startProcessAll(page: Page) {
-  await openMenuItem(page, selectors.menu.processTrigger, selectors.menu.processAll)
+  await openMenuItem(
+    page,
+    selectors.menu.processTrigger,
+    selectors.menu.processAll,
+  )
 }
 
 export async function waitForOperationStart(
@@ -140,12 +155,17 @@ export async function waitForOperationProgressAdvance(
   timeout = 45_000,
 ) {
   const card = page.getByTestId(selectors.operations.card)
-  const initialCurrent = Number((await card.getAttribute('data-current')) ?? '0')
+  const initialCurrent = Number(
+    (await card.getAttribute('data-current')) ?? '0',
+  )
   await expect
-    .poll(async () => {
-      const raw = await card.getAttribute('data-current')
-      const value = Number(raw ?? '0')
-      return Number.isFinite(value) ? value : 0
-    }, { timeout })
+    .poll(
+      async () => {
+        const raw = await card.getAttribute('data-current')
+        const value = Number(raw ?? '0')
+        return Number.isFinite(value) ? value : 0
+      },
+      { timeout },
+    )
     .toBeGreaterThan(initialCurrent)
 }

--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -46,8 +46,10 @@ export const selectors = {
   llm: {
     trigger: 'llm-trigger',
     popover: 'llm-popover',
+    modelSearch: 'llm-model-search',
     modelSelect: 'llm-model-select',
     modelOption: (index: number) => `llm-model-option-${index}`,
+    modelEmpty: 'llm-model-empty',
     languageSelect: 'llm-language-select',
     languageOption: (index: number) => `llm-language-option-${index}`,
     loadToggle: 'llm-load-toggle',

--- a/ui/components/canvas/CanvasToolbar.tsx
+++ b/ui/components/canvas/CanvasToolbar.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { motion } from 'motion/react'
@@ -14,6 +14,7 @@ import {
 } from 'lucide-react'
 import { Separator } from '@/components/ui/separator'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import {
   Select,
@@ -52,6 +53,27 @@ const flattenCatalogModels = (catalog?: LlmCatalog): SelectableLlmModel[] => [
     ),
 ]
 
+const filterCatalogModels = (
+  models: SelectableLlmModel[],
+  query: string,
+): SelectableLlmModel[] => {
+  const normalized = query.trim().toLowerCase()
+  if (!normalized) return models
+
+  return models.filter(({ model, provider }) => {
+    const candidates = [
+      model.name,
+      model.target.modelId,
+      model.target.providerId,
+      provider?.name,
+      provider?.id,
+    ]
+    return candidates.some((candidate) =>
+      candidate?.toLowerCase().includes(normalized),
+    )
+  })
+}
+
 export function CanvasToolbar() {
   return (
     <div className='border-border/60 bg-card text-foreground flex items-center gap-2 border-b px-3 py-2 text-xs'>
@@ -66,7 +88,9 @@ function WorkflowButtons() {
   const { send, isProcessing, state } = useProcessing()
   const { data: llmState } = useGetLlm()
   const llmReady = llmState?.status === 'ready'
-  const hasDocument = useEditorUiStore((state) => state.currentDocumentId !== null)
+  const hasDocument = useEditorUiStore(
+    (state) => state.currentDocumentId !== null,
+  )
   const { t } = useTranslation()
 
   const isDetecting = state.matches('detecting')
@@ -200,6 +224,8 @@ function WorkflowButtons() {
 
 function LlmStatusPopover() {
   const { data: llmCatalog } = useGetLlmCatalog()
+  const [popoverOpen, setPopoverOpen] = useState(false)
+  const [modelSearchQuery, setModelSearchQuery] = useState('')
   const llmModels = useMemo(
     () => flattenCatalogModels(llmCatalog),
     [llmCatalog],
@@ -229,6 +255,10 @@ function LlmStatusPopover() {
       ),
     [llmModels, selectedTarget],
   )
+  const filteredLlmModels = useMemo(
+    () => filterCatalogModels(llmModels, modelSearchQuery),
+    [llmModels, modelSearchQuery],
+  )
   const selectedTargetKey = selectedTarget
     ? llmTargetKey(selectedTarget)
     : undefined
@@ -252,6 +282,7 @@ function LlmStatusPopover() {
       selectedTarget: nextSelection.model.target,
       selectedLanguage: nextLanguage,
     })
+    setModelSearchQuery('')
   }
 
   const handleSetSelectedLanguage = (language: string) => {
@@ -306,7 +337,13 @@ function LlmStatusPopover() {
   }, [llmModels, llmSelectedLanguage, selectedModel?.model, selectedTarget])
 
   return (
-    <Popover>
+    <Popover
+      open={popoverOpen}
+      onOpenChange={(nextOpen) => {
+        setPopoverOpen(nextOpen)
+        if (!nextOpen) setModelSearchQuery('')
+      }}
+    >
       <PopoverTrigger asChild>
         <button
           data-testid='llm-trigger'
@@ -358,6 +395,15 @@ function LlmStatusPopover() {
           <span className='text-muted-foreground text-[10px] font-medium uppercase'>
             {t('llm.model', { defaultValue: 'Model' })}
           </span>
+          <Input
+            data-testid='llm-model-search'
+            value={modelSearchQuery}
+            onChange={(event) => setModelSearchQuery(event.target.value)}
+            placeholder={t('llm.modelSearchPlaceholder', {
+              defaultValue: 'Search models',
+            })}
+            className='h-7 text-xs'
+          />
           <div className='flex items-center gap-1.5'>
             <Select
               value={selectedTargetKey}
@@ -370,22 +416,33 @@ function LlmStatusPopover() {
                 <SelectValue placeholder={t('llm.selectPlaceholder')} />
               </SelectTrigger>
               <SelectContent position='popper'>
-                {llmModels.map(({ model, provider }, index) => (
-                  <SelectItem
-                    key={llmTargetKey(model.target)}
-                    value={llmTargetKey(model.target)}
-                    data-testid={`llm-model-option-${index}`}
+                {filteredLlmModels.length > 0 ? (
+                  filteredLlmModels.map(({ model, provider }, index) => (
+                    <SelectItem
+                      key={llmTargetKey(model.target)}
+                      value={llmTargetKey(model.target)}
+                      data-testid={`llm-model-option-${index}`}
+                    >
+                      <span className='flex items-center gap-1.5'>
+                        {provider ? (
+                          <span className='bg-primary/10 text-primary rounded px-1 py-0.5 text-[9px] leading-none font-semibold uppercase'>
+                            {provider.name}
+                          </span>
+                        ) : null}
+                        {model.name}
+                      </span>
+                    </SelectItem>
+                  ))
+                ) : (
+                  <div
+                    data-testid='llm-model-empty'
+                    className='text-muted-foreground px-2 py-2 text-xs'
                   >
-                    <span className='flex items-center gap-1.5'>
-                      {provider ? (
-                        <span className='bg-primary/10 text-primary rounded px-1 py-0.5 text-[9px] leading-none font-semibold uppercase'>
-                          {provider.name}
-                        </span>
-                      ) : null}
-                      {model.name}
-                    </span>
-                  </SelectItem>
-                ))}
+                    {t('llm.modelSearchNoResults', {
+                      defaultValue: 'No models found',
+                    })}
+                  </div>
+                )}
               </SelectContent>
             </Select>
             <Button


### PR DESCRIPTION
## Summary

- Add searchable model filtering to the LLM popover to resolve issue #406.
- Users can now filter models by name, model ID, provider name, or provider ID.
- Includes explicit empty-state message when no models match.
- Controlled search state clears on selection or popover close to keep UX clean.

## Changes

- `ui/components/canvas/CanvasToolbar.tsx`: Add search input and filtered model list.
- `e2e/helpers/selectors.ts`: Add test IDs for search input and empty state.
- `e2e/helpers/pipeline.ts`: Extend ensureLlmReady helper to test search empty state.

## Old behavior

Users must manually scroll through all available models in the model selector dropdown.

## New behavior

Users can type in the search input to instantly filter the model list. The popover shows "No models found" when no models match the query.

## Verification

- Next.js build: `bun --cwd ui build` - passed.
- Existing model selection and load flow preserved.
