### PR TITLE
docs: correct download button label

### DIFF
--- a/docs/en-US/index.md
+++ b/docs/en-US/index.md
@@ -111,11 +111,6 @@ hide:
     box-shadow: none;
   }
 
-  .kh-download-button__version {
-    color: color-mix(in srgb, var(--kh-pink-ink) 72%, var(--kh-muted));
-    font-weight: 700;
-  }
-
   .kh-hero {
     padding: 0.8rem 0 0;
   }
@@ -494,7 +489,7 @@ hide:
         </div>
         <div class="kh-download-hero">
           <a class="kh-download-button" href="https://github.com/mayocream/koharu/releases/latest">
-            Download for Windows&nbsp;&nbsp;<span class="kh-download-button__version">0.42.1</span>
+            Download
           </a>
           <div class="kh-download-hero__subtext">
             Free and open source.

--- a/docs/ja-JP/index.md
+++ b/docs/ja-JP/index.md
@@ -111,11 +111,6 @@ hide:
     box-shadow: none;
   }
 
-  .kh-download-button__version {
-    color: color-mix(in srgb, var(--kh-pink-ink) 72%, var(--kh-muted));
-    font-weight: 700;
-  }
-
   .kh-hero {
     padding: 0.8rem 0 0;
   }
@@ -494,7 +489,7 @@ hide:
         </div>
         <div class="kh-download-hero">
           <a class="kh-download-button" href="https://github.com/mayocream/koharu/releases/latest">
-            Windows 版をダウンロード&nbsp;&nbsp;<span class="kh-download-button__version">0.42.1</span>
+            ダウンロード
           </a>
           <div class="kh-download-hero__subtext">
             Koharu は無料のオープンソースソフトウェアです。

--- a/docs/zh-CN/index.md
+++ b/docs/zh-CN/index.md
@@ -111,11 +111,6 @@ hide:
     box-shadow: none;
   }
 
-  .kh-download-button__version {
-    color: color-mix(in srgb, var(--kh-pink-ink) 72%, var(--kh-muted));
-    font-weight: 700;
-  }
-
   .kh-hero {
     padding: 0.8rem 0 0;
   }
@@ -494,7 +489,7 @@ hide:
         </div>
         <div class="kh-download-hero">
           <a class="kh-download-button" href="https://github.com/mayocream/koharu/releases/latest">
-            下载 Windows 版&nbsp;&nbsp;<span class="kh-download-button__version">0.42.1</span>
+            下载
           </a>
           <div class="kh-download-hero__subtext">
             Koharu 免费且开源。


### PR DESCRIPTION
Current download button label is static: it states "Download for Windows" regardless of visitor's OS (despite releases for other OS are available); it also lists a fixed version (0.42.1) instead of the actual latest version (as of now 0.43.2).

There are two ways to address this issue:

A. Detect OS and fetch latest release
B. Simply don't show these info

Option B seems more practical, hence this pull request.