### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches: ['main']
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/mayocream/koharu/security/code-scanning/4](https://github.com/mayocream/koharu/security/code-scanning/4)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained to the minimum needed.  
Best fix here: define workflow-level permissions right after `on:` (or before `jobs:`), since there is only one job and no job-specific deviation is needed. Use:

- `contents: read`

This preserves functionality (`actions/checkout` and test execution still work) while preventing unintended write scopes if defaults change.

Edit file: `.github/workflows/test.yml`  
Region: between the `on:` section and `env:` section (after line 7 in the provided snippet).  
No imports/dependencies/methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
