### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,9 @@ on:
     branches: ['main']
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/mayocream/koharu/security/code-scanning/3](https://github.com/mayocream/koharu/security/code-scanning/3)

Add an explicit `permissions` block to `.github/workflows/lint.yml` so `GITHUB_TOKEN` is constrained to least privilege.  
Best fix here: set workflow-level permissions to `contents: read`, which is sufficient for checkout and typical lint steps, and does not grant write scopes.

Change location:
- File: `.github/workflows/lint.yml`
- Insert directly after the `on:` block (before `env:`), or alternatively at job level under `jobs.lint`.  
Workflow-level is simplest and applies consistently to all jobs in this workflow.

No imports, methods, or dependencies are needed—this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
