### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - '*'
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/mayocream/koharu/security/code-scanning/2](https://github.com/mayocream/koharu/security/code-scanning/2)

Add an explicit `permissions` block in `.github/workflows/publish.yml` at the workflow root so it applies to all jobs, unless overridden. The minimal and safest fix here is:

- `contents: read`

This satisfies CodeQL’s requirement and preserves functionality for `actions/checkout` and build/publish steps that do not require write access to GitHub resources. No imports, methods, or additional definitions are needed since this is YAML configuration only. Insert the block after the `on:` trigger section (before `env:`) to keep structure clear and conventional.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
