### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
     branches: ['main']
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/mayocream/koharu/security/code-scanning/1](https://github.com/mayocream/koharu/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root in `.github/workflows/build.yml`, right after the `on:` trigger block (before `env:` is a clean placement).  
For this workflow, the minimal safe baseline is:

- `contents: read`

This preserves current behavior while ensuring token scope is explicitly limited. No imports, methods, or dependencies are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
