### PR TITLE
fix: cuda vulkan thread isolation

### DIFF
--- a/koharu-app/src/pipeline/engines/comic_text_bubble.rs
+++ b/koharu-app/src/pipeline/engines/comic_text_bubble.rs
@@ -41,18 +41,19 @@ impl Engine for Model {
         let (resp_tx, resp_rx) = oneshot::channel();
 
         // Send the image to the dedicated CUDA thread
+        // Send the image to the dedicated thread
         self.sender
             .send(DetectMessage {
                 image,
                 respond_to: resp_tx,
             })
             .await
-            .map_err(|_| anyhow::anyhow!("[SYS] CUDA Detector thread disconnected"))?;
+            .map_err(|_| anyhow::anyhow!("[SYS] Detector thread disconnected"))?;
 
         // Wait asynchronously without blocking Tokio workers
         let det = resp_rx
             .await
-            .map_err(|_| anyhow::anyhow!("[SYS] CUDA Detector thread crashed"))??;
+            .map_err(|_| anyhow::anyhow!("[SYS] Detector thread crashed"))??;
 
         let mut pairs: Vec<([f32; 4], TextData)> = det
             .text_blocks

--- a/koharu-app/src/pipeline/engines/comic_text_bubble.rs
+++ b/koharu-app/src/pipeline/engines/comic_text_bubble.rs
@@ -3,27 +3,38 @@
 //! the scene layer — bubble geometry is derived from the detected text
 //! regions and the segmentation mask.
 
-use anyhow::Result;
-use async_trait::async_trait;
-use koharu_core::{Op, TextData};
-use koharu_ml::comic_text_bubble_detector::ComicTextBubbleDetector;
-
-use crate::pipeline::artifacts::Artifact;
-use crate::pipeline::engine::{Engine, EngineCtx, EngineInfo};
-use crate::pipeline::engines::support::{
-    clear_text_nodes_ops, load_source_image, new_text_node, page_node_count,
-    sort_manga_reading_order, text_region_to_pair,
-};
+use std::thread;
+use tokio::sync::{mpsc, oneshot};
+use tokio::runtime::Builder;
 
 const DETECTOR_NAME: &str = "comic-text-bubble-detector";
 
-pub struct Model(ComicTextBubbleDetector);
+// 1. Define the communication protocol
+struct DetectMessage {
+    image: koharu_core::image::DynamicImage,
+    respond_to: oneshot::Sender<Result<koharu_ml::comic_text_bubble_detector::ComicTextBubbleDetection>>,
+}
+
+// 2. The Engine now acts as an Async Client to the dedicated thread
+pub struct Model {
+    sender: mpsc::Sender<DetectMessage>,
+}
 
 #[async_trait]
 impl Engine for Model {
     async fn run(&self, ctx: EngineCtx<'_>) -> Result<Vec<Op>> {
         let image = load_source_image(ctx.scene, ctx.page, ctx.blobs)?;
-        let det = self.0.inference(&image)?;
+        
+        // Create a one-time return channel
+        let (resp_tx, resp_rx) = oneshot::channel();
+        
+        // Send the image to the dedicated CUDA thread
+        self.sender.send(DetectMessage { image, respond_to: resp_tx })
+            .await
+            .map_err(|_| anyhow::anyhow!("[SYS] CUDA Detector thread disconnected"))?;
+
+        // Wait asynchronously without blocking Tokio workers
+        let det = resp_rx.await.map_err(|_| anyhow::anyhow!("[SYS] CUDA Detector thread crashed"))??;
 
         let mut pairs: Vec<([f32; 4], TextData)> = det
             .text_blocks
@@ -48,6 +59,7 @@ impl Engine for Model {
     }
 }
 
+// 3. Spawning the isolated OS Thread during Engine Load
 inventory::submit! {
     EngineInfo {
         id: "comic-text-bubble-detector",
@@ -55,8 +67,32 @@ inventory::submit! {
         needs: &[],
         produces: &[Artifact::TextBoxes],
         load: |runtime, cpu| Box::pin(async move {
-            let m = ComicTextBubbleDetector::load(runtime, cpu).await?;
-            Ok(Box::new(Model(m)) as Box<dyn Engine>)
+            let (tx, mut rx) = mpsc::channel::<DetectMessage>(8);
+            let runtime_clone = runtime.clone(); // Clone Arc for the thread
+            
+            thread::spawn(move || {
+                // Initialize an isolated single-threaded runtime strictly for this OS thread
+                let rt = Builder::new_current_thread().enable_all().build().unwrap();
+                rt.block_on(async move {
+                    
+                    // The CUDA context is now permanently tied to this specific thread
+                    let detector = match ComicTextBubbleDetector::load(&runtime_clone, cpu).await {
+                        Ok(d) => d,
+                        Err(e) => {
+                            tracing::error!("Failed to load detector: {:?}", e);
+                            return;
+                        }
+                    };
+
+                    // Listen continuously for pipeline requests
+                    while let Some(msg) = rx.recv().await {
+                        let result = detector.inference(&msg.image);
+                        let _ = msg.respond_to.send(result);
+                    }
+                });
+            });
+
+            Ok(Box::new(Model { sender: tx }) as Box<dyn Engine>)
         }),
     }
 }

--- a/koharu-app/src/pipeline/engines/comic_text_bubble.rs
+++ b/koharu-app/src/pipeline/engines/comic_text_bubble.rs
@@ -6,7 +6,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use koharu_core::{Op, TextData};
-use koharu_ml::comic_text_bubble_detector::{ComicTextBubbleDetector, ComicTextBubbleDetection};
+use koharu_ml::comic_text_bubble_detector::{ComicTextBubbleDetection, ComicTextBubbleDetector};
 
 use crate::pipeline::artifacts::Artifact;
 use crate::pipeline::engine::{Engine, EngineCtx, EngineInfo};
@@ -16,8 +16,8 @@ use crate::pipeline::engines::support::{
 };
 
 use std::thread;
-use tokio::sync::{mpsc, oneshot};
 use tokio::runtime::Builder;
+use tokio::sync::{mpsc, oneshot};
 
 const DETECTOR_NAME: &str = "comic-text-bubble-detector";
 
@@ -41,12 +41,18 @@ impl Engine for Model {
         let (resp_tx, resp_rx) = oneshot::channel();
 
         // Send the image to the dedicated CUDA thread
-        self.sender.send(DetectMessage { image, respond_to: resp_tx })
+        self.sender
+            .send(DetectMessage {
+                image,
+                respond_to: resp_tx,
+            })
             .await
             .map_err(|_| anyhow::anyhow!("[SYS] CUDA Detector thread disconnected"))?;
 
         // Wait asynchronously without blocking Tokio workers
-        let det = resp_rx.await.map_err(|_| anyhow::anyhow!("[SYS] CUDA Detector thread crashed"))??;
+        let det = resp_rx
+            .await
+            .map_err(|_| anyhow::anyhow!("[SYS] CUDA Detector thread crashed"))??;
 
         let mut pairs: Vec<([f32; 4], TextData)> = det
             .text_blocks

--- a/koharu-app/src/pipeline/engines/comic_text_bubble.rs
+++ b/koharu-app/src/pipeline/engines/comic_text_bubble.rs
@@ -3,6 +3,18 @@
 //! the scene layer — bubble geometry is derived from the detected text
 //! regions and the segmentation mask.
 
+use anyhow::Result;
+use async_trait::async_trait;
+use koharu_core::{Op, TextData};
+use koharu_ml::comic_text_bubble_detector::{ComicTextBubbleDetector, ComicTextBubbleDetection};
+
+use crate::pipeline::artifacts::Artifact;
+use crate::pipeline::engine::{Engine, EngineCtx, EngineInfo};
+use crate::pipeline::engines::support::{
+    clear_text_nodes_ops, load_source_image, new_text_node, page_node_count,
+    sort_manga_reading_order, text_region_to_pair,
+};
+
 use std::thread;
 use tokio::sync::{mpsc, oneshot};
 use tokio::runtime::Builder;
@@ -11,8 +23,8 @@ const DETECTOR_NAME: &str = "comic-text-bubble-detector";
 
 // 1. Define the communication protocol
 struct DetectMessage {
-    image: koharu_core::image::DynamicImage,
-    respond_to: oneshot::Sender<Result<koharu_ml::comic_text_bubble_detector::ComicTextBubbleDetection>>,
+    image: image::DynamicImage,
+    respond_to: oneshot::Sender<Result<ComicTextBubbleDetection>>,
 }
 
 // 2. The Engine now acts as an Async Client to the dedicated thread
@@ -24,10 +36,10 @@ pub struct Model {
 impl Engine for Model {
     async fn run(&self, ctx: EngineCtx<'_>) -> Result<Vec<Op>> {
         let image = load_source_image(ctx.scene, ctx.page, ctx.blobs)?;
-        
+
         // Create a one-time return channel
         let (resp_tx, resp_rx) = oneshot::channel();
-        
+
         // Send the image to the dedicated CUDA thread
         self.sender.send(DetectMessage { image, respond_to: resp_tx })
             .await
@@ -69,12 +81,12 @@ inventory::submit! {
         load: |runtime, cpu| Box::pin(async move {
             let (tx, mut rx) = mpsc::channel::<DetectMessage>(8);
             let runtime_clone = runtime.clone(); // Clone Arc for the thread
-            
+
             thread::spawn(move || {
                 // Initialize an isolated single-threaded runtime strictly for this OS thread
                 let rt = Builder::new_current_thread().enable_all().build().unwrap();
                 rt.block_on(async move {
-                    
+
                     // The CUDA context is now permanently tied to this specific thread
                     let detector = match ComicTextBubbleDetector::load(&runtime_clone, cpu).await {
                         Ok(d) => d,

--- a/koharu-ml/src/comic_text_bubble_detector/mod.rs
+++ b/koharu-ml/src/comic_text_bubble_detector/mod.rs
@@ -129,14 +129,17 @@ impl ComicTextBubbleDetector {
         threshold: f32,
     ) -> Result<Vec<ComicTextBubbleRegion>> {
         let pixel_values = preprocess_image(image, &self.preprocessor, &self.device, self.dtype)?;
-        let outputs = self.model.forward(&pixel_values)?;
-        let results =
-            post_process_object_detection(&self.config, &outputs, image.dimensions(), threshold);
+
+        // Wrap the forward pass and post-processing in a closure so we can capture
+        // any errors without returning from the outer function immediately.
+        let inference_result = (|| -> Result<Vec<ComicTextBubbleRegion>> {
+            let outputs = self.model.forward(&pixel_values)?;
+            post_process_object_detection(&self.config, &outputs, image.dimensions(), threshold)
+        })();
 
         // EXPLICIT VRAM CLEANUP
-        // Drop the tensors manually before synchronizing
+        // This is now guaranteed to run even if the forward pass fails and returns an Err
         drop(pixel_values);
-        drop(outputs);
 
         // Force the CUDA device to flush its command queue and release memory
         // back to the OS so Vulkan (llama.cpp) can safely use it.
@@ -144,7 +147,7 @@ impl ComicTextBubbleDetector {
             let _ = self.device.synchronize();
         }
 
-        results
+        inference_result
     }
 }
 

--- a/koharu-ml/src/comic_text_bubble_detector/mod.rs
+++ b/koharu-ml/src/comic_text_bubble_detector/mod.rs
@@ -130,7 +130,20 @@ impl ComicTextBubbleDetector {
     ) -> Result<Vec<ComicTextBubbleRegion>> {
         let pixel_values = preprocess_image(image, &self.preprocessor, &self.device, self.dtype)?;
         let outputs = self.model.forward(&pixel_values)?;
-        post_process_object_detection(&self.config, &outputs, image.dimensions(), threshold)
+        let results = post_process_object_detection(&self.config, &outputs, image.dimensions(), threshold);
+        
+        // EXPLICIT VRAM CLEANUP
+        // Drop the tensors manually before synchronizing
+        drop(pixel_values);
+        drop(outputs);
+
+        // Force the CUDA device to flush its command queue and release memory 
+        // back to the OS so Vulkan (llama.cpp) can safely use it.
+        if self.device.is_cuda() {
+            let _ = self.device.synchronize();
+        }
+
+        results
     }
 }
 

--- a/koharu-ml/src/comic_text_bubble_detector/mod.rs
+++ b/koharu-ml/src/comic_text_bubble_detector/mod.rs
@@ -130,14 +130,15 @@ impl ComicTextBubbleDetector {
     ) -> Result<Vec<ComicTextBubbleRegion>> {
         let pixel_values = preprocess_image(image, &self.preprocessor, &self.device, self.dtype)?;
         let outputs = self.model.forward(&pixel_values)?;
-        let results = post_process_object_detection(&self.config, &outputs, image.dimensions(), threshold);
-        
+        let results =
+            post_process_object_detection(&self.config, &outputs, image.dimensions(), threshold);
+
         // EXPLICIT VRAM CLEANUP
         // Drop the tensors manually before synchronizing
         drop(pixel_values);
         drop(outputs);
 
-        // Force the CUDA device to flush its command queue and release memory 
+        // Force the CUDA device to flush its command queue and release memory
         // back to the OS so Vulkan (llama.cpp) can safely use it.
         if self.device.is_cuda() {
             let _ = self.device.synchronize();


### PR DESCRIPTION
Resolves #340 

**Architecture Flaw Identified:**
The `CUBLAS_STATUS_NOT_INITIALIZED` crashes are caused by a collision between Tokio's async worker threads and hardware-level GPU contexts. Tokio's `spawn_blocking` assigns inference tasks to random worker threads, causing context loss for `candle_core` (which requires thread-local storage for cuBLAS/CUDA handles).

**The Solution:**
* **Actor Model Isolation:** Ripped the `candle_core` execution out of Tokio's `spawn_blocking` pool. The detector now runs on a single, dedicated OS thread (`std::thread::spawn`), communicating with the Axum backend via `tokio::sync::mpsc` and `oneshot` channels. 
* **Aggressive VRAM Syncing:** Added explicit VRAM cleanup to drop tensors and flush the CUDA queue after object detection.
* This permanently pins the CUDA context to a single thread, preventing the Vulkan/CUDA threading panics entirely.

Tested locally. Inference now executes sequentially and safely without context panics.