### PR TITLE
Select bundled CUDA runtime based on driver version

### DIFF
--- a/koharu-runtime/src/cuda.rs
+++ b/koharu-runtime/src/cuda.rs
@@ -11,7 +11,8 @@ use crate::loader::{add_runtime_search_path, preload_library};
 const CUDA_SUCCESS: i32 = 0;
 const CUDA_13_0_DRIVER_VERSION: i32 = 13000;
 const CUDA_13_1_DRIVER_VERSION: i32 = 13010;
-const CUDA_EXTRACT_REVISION: u32 = 2;
+const CUDA_13_2_DRIVER_VERSION: i32 = 13020;
+const CUDA_EXTRACT_REVISION: u32 = 3;
 const CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR: i32 = 75;
 const CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR: i32 = 76;
 const MIN_COMPUTE_CAPABILITY: (i32, i32) = (8, 0); // Ampere (RTX 30xx) and above
@@ -44,7 +45,12 @@ struct WheelSpec {
     linux_dylibs: &'static [&'static str],
 }
 
-const WHEELS: &[WheelSpec] = &[
+struct WheelSet {
+    name: &'static str,
+    wheels: &'static [WheelSpec],
+}
+
+const CUDA_13_0_WHEELS: &[WheelSpec] = &[
     WheelSpec {
         package: "nvidia-cuda-runtime/13.0.96",
         windows_dylibs: &["cudart64_13.dll"],
@@ -92,6 +98,64 @@ const WHEELS: &[WheelSpec] = &[
     },
 ];
 
+const CUDA_13_2_UPDATE_1_WHEELS: &[WheelSpec] = &[
+    WheelSpec {
+        package: "nvidia-cuda-runtime/13.2.75",
+        windows_dylibs: &["cudart64_13.dll"],
+        linux_dylibs: &["libcudart.so.13"],
+    },
+    WheelSpec {
+        package: "nvidia-cublas/13.4.0.1",
+        windows_dylibs: &["cublasLt64_13.dll", "cublas64_13.dll"],
+        linux_dylibs: &["libcublasLt.so.13", "libcublas.so.13"],
+    },
+    WheelSpec {
+        package: "nvidia-cufft/12.2.0.46",
+        windows_dylibs: &["cufft64_12.dll"],
+        linux_dylibs: &["libcufft.so.12"],
+    },
+    WheelSpec {
+        package: "nvidia-curand/10.4.2.55",
+        windows_dylibs: &["curand64_10.dll"],
+        linux_dylibs: &["libcurand.so.10"],
+    },
+    WheelSpec {
+        package: "nvidia-cudnn-cu13/9.21.0.82",
+        windows_dylibs: &[
+            "cudnn64_9.dll",
+            "cudnn_adv64_9.dll",
+            "cudnn_cnn64_9.dll",
+            "cudnn_engines_precompiled64_9.dll",
+            "cudnn_engines_runtime_compiled64_9.dll",
+            "cudnn_engines_tensor_ir64_9.dll",
+            "cudnn_graph64_9.dll",
+            "cudnn_heuristic64_9.dll",
+            "cudnn_ops64_9.dll",
+        ],
+        linux_dylibs: &[
+            "libcudnn.so.9",
+            "libcudnn_adv.so.9",
+            "libcudnn_cnn.so.9",
+            "libcudnn_engines_precompiled.so.9",
+            "libcudnn_engines_runtime_compiled.so.9",
+            "libcudnn_engines_tensor_ir.so.9",
+            "libcudnn_graph.so.9",
+            "libcudnn_heuristic.so.9",
+            "libcudnn_ops.so.9",
+        ],
+    },
+];
+
+const CUDA_13_0_WHEEL_SET: WheelSet = WheelSet {
+    name: "cuda-13.0",
+    wheels: CUDA_13_0_WHEELS,
+};
+
+const CUDA_13_2_UPDATE_1_WHEEL_SET: WheelSet = WheelSet {
+    name: "cuda-13.2-update1",
+    wheels: CUDA_13_2_UPDATE_1_WHEELS,
+};
+
 impl CudaDriverVersion {
     pub const fn from_raw(raw: i32) -> Self {
         Self { raw }
@@ -115,6 +179,10 @@ impl CudaDriverVersion {
 
     pub const fn supports_cuda_13_1(self) -> bool {
         self.raw >= CUDA_13_1_DRIVER_VERSION
+    }
+
+    pub const fn supports_cuda_13_2(self) -> bool {
+        self.raw >= CUDA_13_2_DRIVER_VERSION
     }
 }
 
@@ -287,13 +355,15 @@ pub(crate) fn llama_cuda_enabled(runtime: &Runtime) -> bool {
 
 pub(crate) fn package_present(runtime: &Runtime) -> Result<bool> {
     let install_dir = install_dir(runtime);
-    let source_id = source_id()?;
+    let wheel_set = selected_wheel_set()?;
+    let source_id = source_id_for_wheel_set(wheel_set)?;
     let install = InstallState::new(&install_dir, &source_id);
     if !install.is_current() {
         return Ok(false);
     }
 
-    Ok(WHEELS
+    Ok(wheel_set
+        .wheels
         .iter()
         .flat_map(|wheel| wheel.dylibs().iter())
         .all(|dylib| install_dir.join(dylib).exists()))
@@ -305,13 +375,14 @@ pub(crate) async fn package_prepare(runtime: &Runtime) -> Result<()> {
 
 pub(crate) async fn ensure_ready(runtime: &Runtime) -> Result<()> {
     let install_dir = install_dir(runtime);
-    let source_id = source_id()?;
+    let wheel_set = selected_wheel_set()?;
+    let source_id = source_id_for_wheel_set(wheel_set)?;
     let install = InstallState::new(&install_dir, &source_id);
 
     if !install.is_current() {
         install.reset()?;
 
-        for wheel in WHEELS {
+        for wheel in wheel_set.wheels {
             let asset = select_wheel(runtime, wheel).await?;
             let archive = runtime
                 .downloads()
@@ -330,7 +401,7 @@ pub(crate) async fn ensure_ready(runtime: &Runtime) -> Result<()> {
     }
 
     add_runtime_search_path(&install_dir)?;
-    for wheel in WHEELS {
+    for wheel in wheel_set.wheels {
         for dylib in wheel.dylibs() {
             let path = install_dir.join(dylib);
             if path.exists() {
@@ -402,11 +473,40 @@ impl WheelSpec {
     }
 }
 
-fn source_id() -> Result<String> {
-    let packages = WHEELS.iter().map(|wheel| wheel.package).collect::<Vec<_>>();
+impl WheelSet {
+    fn packages(&self) -> Vec<&'static str> {
+        self.wheels.iter().map(|wheel| wheel.package).collect()
+    }
+}
+
+fn wheel_set_for_driver(version: CudaDriverVersion) -> &'static WheelSet {
+    if version.supports_cuda_13_2() {
+        &CUDA_13_2_UPDATE_1_WHEEL_SET
+    } else {
+        &CUDA_13_0_WHEEL_SET
+    }
+}
+
+fn selected_wheel_set() -> Result<&'static WheelSet> {
+    let version = driver_version()?;
+    let wheel_set = wheel_set_for_driver(version);
+    let packages = wheel_set.packages();
+    tracing::info!(
+        cuda_driver_version = %version,
+        cuda_driver_version_raw = version.raw(),
+        cuda_wheel_set = wheel_set.name,
+        cuda_packages = ?packages,
+        "Selected bundled CUDA runtime wheel set"
+    );
+    Ok(wheel_set)
+}
+
+fn source_id_for_wheel_set(wheel_set: &WheelSet) -> Result<String> {
+    let packages = wheel_set.packages();
     Ok(format!(
-        "cuda;platform={};wheels={};extract={}",
+        "cuda;platform={};wheel-set={};wheels={};extract={}",
         platform_tags()?.join(","),
+        wheel_set.name,
         packages.join(","),
         CUDA_EXTRACT_REVISION
     ))
@@ -447,21 +547,30 @@ mod tests {
     use super::*;
 
     #[test]
-    fn source_id_includes_platform() {
-        let id = source_id().unwrap();
-        assert!(id.contains("cuda"));
-        assert!(id.contains("platform="));
+    fn source_id_includes_selected_set_and_platform() {
+        for wheel_set in [&CUDA_13_0_WHEEL_SET, &CUDA_13_2_UPDATE_1_WHEEL_SET] {
+            let id = source_id_for_wheel_set(wheel_set).unwrap();
+            assert!(id.contains("cuda"));
+            assert!(id.contains("platform="));
+            assert!(id.contains(&format!("wheel-set={}", wheel_set.name)));
+            for package in wheel_set.packages() {
+                assert!(id.contains(package), "missing {package} in {id}");
+            }
+        }
     }
 
     #[test]
     #[cfg(any(target_os = "windows", target_os = "linux"))]
-    fn wheels_have_dylibs_for_current_platform() {
-        for wheel in WHEELS {
-            assert!(
-                !wheel.dylibs().is_empty(),
-                "{} has no dylibs",
-                wheel.package
-            );
+    fn wheel_sets_have_dylibs_for_current_platform() {
+        for wheel_set in [&CUDA_13_0_WHEEL_SET, &CUDA_13_2_UPDATE_1_WHEEL_SET] {
+            for wheel in wheel_set.wheels {
+                assert!(
+                    !wheel.dylibs().is_empty(),
+                    "{} in {} has no dylibs",
+                    wheel.package,
+                    wheel_set.name
+                );
+            }
         }
     }
 
@@ -470,13 +579,14 @@ mod tests {
         let tempdir = tempfile::tempdir().unwrap();
         let root = tempdir.path();
 
-        for wheel in WHEELS {
+        for wheel in CUDA_13_2_UPDATE_1_WHEEL_SET.wheels {
             for dylib in wheel.dylibs() {
                 std::fs::write(root.join(dylib), b"ok").unwrap();
             }
         }
 
-        let all_dylibs: Vec<&str> = WHEELS
+        let all_dylibs: Vec<&str> = CUDA_13_2_UPDATE_1_WHEEL_SET
+            .wheels
             .iter()
             .flat_map(|wheel| wheel.dylibs().iter().copied())
             .collect();
@@ -486,17 +596,20 @@ mod tests {
     }
 
     #[test]
-    fn cuda_runtime_includes_cudnn() {
-        let wheel = WHEELS
-            .iter()
-            .find(|wheel| wheel.package.starts_with("nvidia-cudnn-cu13/"))
-            .expect("missing cuDNN runtime wheel");
+    fn cuda_runtime_includes_cudnn_in_all_wheel_sets() {
+        for wheel_set in [&CUDA_13_0_WHEEL_SET, &CUDA_13_2_UPDATE_1_WHEEL_SET] {
+            let wheel = wheel_set
+                .wheels
+                .iter()
+                .find(|wheel| wheel.package.starts_with("nvidia-cudnn-cu13/"))
+                .unwrap_or_else(|| panic!("missing cuDNN runtime wheel in {}", wheel_set.name));
 
-        #[cfg(target_os = "windows")]
-        assert!(wheel.dylibs().contains(&"cudnn64_9.dll"));
+            #[cfg(target_os = "windows")]
+            assert!(wheel.dylibs().contains(&"cudnn64_9.dll"));
 
-        #[cfg(target_os = "linux")]
-        assert!(wheel.dylibs().contains(&"libcudnn.so.9"));
+            #[cfg(target_os = "linux")]
+            assert!(wheel.dylibs().contains(&"libcudnn.so.9"));
+        }
     }
 
     #[test]
@@ -521,5 +634,29 @@ mod tests {
         assert!(CudaDriverVersion::from_raw(13020).supports_cuda_13_1());
         assert!(!CudaDriverVersion::from_raw(13000).supports_cuda_13_1());
         assert!(!CudaDriverVersion::from_raw(12080).supports_cuda_13_1());
+    }
+
+    #[test]
+    fn checks_cuda_13_2_threshold() {
+        assert!(CudaDriverVersion::from_raw(13020).supports_cuda_13_2());
+        assert!(CudaDriverVersion::from_raw(13030).supports_cuda_13_2());
+        assert!(!CudaDriverVersion::from_raw(13010).supports_cuda_13_2());
+        assert!(!CudaDriverVersion::from_raw(12080).supports_cuda_13_2());
+    }
+
+    #[test]
+    fn cuda_13_2_driver_selects_cuda_13_2_wheel_set() {
+        let wheel_set = wheel_set_for_driver(CudaDriverVersion::from_raw(13020));
+        assert_eq!(wheel_set.name, "cuda-13.2-update1");
+        assert!(wheel_set.packages().contains(&"nvidia-cublas/13.4.0.1"));
+    }
+
+    #[test]
+    fn cuda_13_0_and_13_1_drivers_keep_cuda_13_0_wheel_set() {
+        for raw in [13000, 13010] {
+            let wheel_set = wheel_set_for_driver(CudaDriverVersion::from_raw(raw));
+            assert_eq!(wheel_set.name, "cuda-13.0");
+            assert!(wheel_set.packages().contains(&"nvidia-cublas/13.0.2.14"));
+        }
     }
 }


### PR DESCRIPTION
### Summary

This PR makes bundled CUDA runtime selection driver-aware.

Koharu previously installed/preloaded a single CUDA 13.0-era bundled runtime set. On an RTX 5060 Ti / Blackwell / `sm_120` system where the NVIDIA driver reports CUDA 13.2 support, that runtime selection caused multiple Candle CUDA vision engines to fail with:

`CublasError(CUBLAS_STATUS_INVALID_VALUE)`

This PR adds separate named bundled CUDA wheel sets and selects the appropriate set from `driver_version()`:

- `cuda-13.0`
- `cuda-13.2-update1`

The selected wheel set is now used consistently for:

- install presence checks
- extraction
- preload
- install/source marker generation

The runtime logs now include:

- `cuda_wheel_set`
- selected CUDA package list

`CUDA_EXTRACT_REVISION` is bumped to `3`, and the install/source marker now includes both the selected wheel set and the concrete package list. This invalidates stale CUDA 13.0 runtime caches on CUDA 13.2-capable systems.

### Related issues / PRs

Related to #340.

#340 originally tracked Linux CUDA/cuBLAS failures, including `CUBLAS_STATUS_NOT_INITIALIZED` and later `CUBLAS_STATUS_INVALID_VALUE` failures in CUDA vision engines.

Follow-up to #702.

#702 fixed one class of CUDA/Vulkan/threading failures by isolating CUDA inference for `comic-text-bubble-detector` onto a dedicated OS thread. This PR addresses a different remaining failure mode: the bundled CUDA runtime itself could still be too old for CUDA 13.2-capable Blackwell / `sm_120` systems.

### Problem observed

On Koharu 0.59.2, GPU mode failed on multiple vision engines with:

`CublasError(CUBLAS_STATUS_INVALID_VALUE)`

Observed failing engines included:

- `pp-doclayout-v3`
- `comic-text-bubble-detector`
- `yuzumarker-font-detection`

Some CUDA vision engines still succeeded in the same setup, for example:

- `speech-bubble-segmentation`
- `comic-text-detector` in one tested configuration

That made this look less like a single model/pipeline bug and more like a CUDA/cuBLAS runtime compatibility issue.

### Environment tested

- OS: Arch Linux
- App: `koharu-bin` / local source build
- GPU: NVIDIA GeForce RTX 5060 Ti
- Compute capability: `12.0`
- NVIDIA driver reports CUDA `13.2`
- CPU: AMD Ryzen 9 7950X
- Koharu version before patch: `0.59.2`

### Before

Koharu selected and extracted the CUDA 13.0-era bundled runtime even on a CUDA 13.2-capable driver.

GPU pipeline failures included:

```text
pipeline step failed: CublasError(CUBLAS_STATUS_INVALID_VALUE)
engine=pp-doclayout-v3
````

```text
pipeline step failed: CublasError(CUBLAS_STATUS_INVALID_VALUE)
engine=comic-text-bubble-detector
```

```text
pipeline step failed: CublasError(CUBLAS_STATUS_INVALID_VALUE)
engine=yuzumarker-font-detection
```

### After

On the same RTX 5060 Ti system, Koharu selects the CUDA 13.2 update wheel set, invalidates the stale extracted CUDA 13.0 runtime cache, reinstalls/extracts the selected runtime, and GPU mode works correctly.

This is not a CPU fallback. GPU acceleration remains enabled.

### User-visible behavior

Users with CUDA 13.2-capable NVIDIA drivers may now receive the newer bundled CUDA runtime set automatically.

Users with older supported CUDA drivers continue to receive the CUDA 13.0 runtime set.

The selected runtime is now visible in logs through `cuda_wheel_set` and the selected package list, which should make future CUDA runtime issues easier to diagnose.

### Verification

Passed:

```bash
cargo fmt
cargo test -p koharu-runtime cuda --no-default-features
cargo check -p koharu-app --features cuda
cargo test -p koharu-app cuda_actor --no-default-features
cargo check -p koharu-ml --features cuda
```

Note: `cargo test -p koharu-app cuda_actor --no-default-features` completed successfully but matched `0` tests.

Manual verification:

* Before patch: GPU mode failed with `CublasError(CUBLAS_STATUS_INVALID_VALUE)` in multiple vision engines.
* After patch: GPU mode works correctly on the same RTX 5060 Ti system after reinstalling/extracting the selected CUDA runtime.

### AI assistance

The patch was AI-assisted, but the change was reviewed and tested locally before submission.

```
::contentReference[oaicite:1]{index=1}
```

[1]: https://github.com/mayocream/koharu/issues/340 "[BUG] CUBLAS_STATUS_NOT_INITIALIZED on Linux · Issue #340 · mayocream/koharu · GitHub"