### PR TITLE
[codex] Handle long-page slicing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,10 +37,17 @@ jobs:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
       - uses: Swatinem/rust-cache@v2
+      - name: Free disk space
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+          sudo apt-get clean
+          df -h
       - uses: Jimver/cuda-toolkit@master
         if: matrix.os == 'ubuntu-latest'
         with:
           cuda: '13.0.0'
+          linux-local-args: '["--toolkit"]'
           log-file-suffix: '${{ matrix.os }}.txt'
       - uses: Jimver/cuda-toolkit@master
         if: matrix.os == 'windows-latest'

--- a/koharu-app/src/ai.rs
+++ b/koharu-app/src/ai.rs
@@ -257,7 +257,7 @@ impl AiManager {
                     let generated = image::load_from_memory(&generated_bytes)
                         .with_context(|| "failed to decode Codex image result")?;
                     let (width, height) = image_dimensions(&generated);
-                    let blob = session.blobs.put_webp(&generated)?;
+                    let blob = session.blobs.put_image(&generated)?;
                     Ok::<_, anyhow::Error>((width, height, blob))
                 })?;
             tracing::info!(width, height, "decoded and stored Codex generated image");

--- a/koharu-app/src/blobs.rs
+++ b/koharu-app/src/blobs.rs
@@ -12,13 +12,14 @@ use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
-use image::{DynamicImage, RgbaImage};
+use image::{DynamicImage, ImageFormat, RgbaImage};
 use koharu_core::BlobRef;
 use lru::LruCache;
 use parking_lot::Mutex;
 
 const IMAGE_CACHE_CAPACITY: usize = 64;
 const RAW_MAGIC: &[u8; 4] = b"RGBA";
+const WEBP_MAX_DIMENSION: u32 = 16_383;
 
 /// Content-addressed blob store + decoded-image LRU.
 pub struct BlobStore {
@@ -84,11 +85,12 @@ impl BlobStore {
         Ok(img)
     }
 
-    /// Encode an image as WebP, store, cache, return ref.
-    pub fn put_webp(&self, img: &DynamicImage) -> Result<BlobRef> {
-        let mut buf = Cursor::new(Vec::new());
-        img.write_to(&mut buf, image::ImageFormat::WebP)?;
-        let r = self.put_bytes(&buf.into_inner())?;
+    /// Encode an image, preferring WebP and falling back to PNG for oversized
+    /// dimensions, then store/cache/return the ref. The stored format is an
+    /// implementation detail; readers should go through `load_image`.
+    pub fn put_image(&self, img: &DynamicImage) -> Result<BlobRef> {
+        let bytes = encode_preferred_image(img)?;
+        let r = self.put_bytes(&bytes)?;
         self.cache.lock().put(r.clone(), img.clone());
         Ok(r)
     }
@@ -135,9 +137,31 @@ fn decode_blob(bytes: &[u8]) -> Result<DynamicImage> {
     Ok(image::load_from_memory(bytes)?)
 }
 
+fn encode_preferred_image(img: &DynamicImage) -> Result<Vec<u8>> {
+    if img.width() <= WEBP_MAX_DIMENSION && img.height() <= WEBP_MAX_DIMENSION {
+        let mut buf = Cursor::new(Vec::new());
+        match img.write_to(&mut buf, ImageFormat::WebP) {
+            Ok(()) => return Ok(buf.into_inner()),
+            Err(err) => {
+                tracing::warn!(
+                    width = img.width(),
+                    height = img.height(),
+                    error = %err,
+                    "WebP encode failed, falling back to PNG"
+                );
+            }
+        }
+    }
+
+    let mut buf = Cursor::new(Vec::new());
+    img.write_to(&mut buf, ImageFormat::Png)?;
+    Ok(buf.into_inner())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use image::{Rgba, RgbaImage};
     use tempfile::tempdir;
 
     #[test]
@@ -158,5 +182,18 @@ mod tests {
         let a = store.put_bytes(b"x").unwrap();
         let b = store.put_bytes(b"x").unwrap();
         assert_eq!(a, b);
+    }
+
+    #[test]
+    fn oversized_webp_falls_back_to_png() {
+        let img = DynamicImage::ImageRgba8(RgbaImage::from_pixel(
+            1,
+            WEBP_MAX_DIMENSION + 1,
+            Rgba([0, 0, 0, 255]),
+        ));
+
+        let bytes = encode_preferred_image(&img).unwrap();
+
+        assert!(bytes.starts_with(b"\x89PNG\r\n\x1a\n"));
     }
 }

--- a/koharu-app/src/pipeline/engines/aot.rs
+++ b/koharu-app/src/pipeline/engines/aot.rs
@@ -60,7 +60,7 @@ impl Engine for Model {
 
         let result = self.0.inference(&image, &mask, &bubble_mask)?;
         let (w, h) = image_dimensions(&result);
-        let blob = ctx.blobs.put_webp(&result)?;
+        let blob = ctx.blobs.put_image(&result)?;
         Ok(vec![upsert_image_blob(
             ctx.scene,
             ctx.page,

--- a/koharu-app/src/pipeline/engines/bubble_segmentation.rs
+++ b/koharu-app/src/pipeline/engines/bubble_segmentation.rs
@@ -25,7 +25,7 @@ impl Engine for Model {
         regions.sort_by_key(|region| std::cmp::Reverse(region.area));
         let mask = paint_bubble_id_mask(result.image_width, result.image_height, &regions);
 
-        let blob = ctx.blobs.put_webp(&DynamicImage::ImageLuma8(mask))?;
+        let blob = ctx.blobs.put_image(&DynamicImage::ImageLuma8(mask))?;
         Ok(vec![upsert_mask_blob(
             ctx.scene,
             ctx.page,

--- a/koharu-app/src/pipeline/engines/ctd_full.rs
+++ b/koharu-app/src/pipeline/engines/ctd_full.rs
@@ -26,7 +26,7 @@ impl Engine for Model {
         let det = self.0.inference(&image)?;
 
         // Segmentation mask blob.
-        let mask_blob = ctx.blobs.put_webp(&DynamicImage::ImageLuma8(det.mask))?;
+        let mask_blob = ctx.blobs.put_image(&DynamicImage::ImageLuma8(det.mask))?;
 
         let mut ops = clear_text_nodes_ops(ctx.scene, ctx.page);
         let removed = ops.len();

--- a/koharu-app/src/pipeline/engines/ctd_segment.rs
+++ b/koharu-app/src/pipeline/engines/ctd_segment.rs
@@ -28,7 +28,7 @@ impl Engine for Model {
             .collect();
 
         let mask = refine_segmentation_mask(&image, &prob_mask, &regions);
-        let mask_blob = ctx.blobs.put_webp(&DynamicImage::ImageLuma8(mask))?;
+        let mask_blob = ctx.blobs.put_image(&DynamicImage::ImageLuma8(mask))?;
 
         Ok(vec![upsert_mask_blob(
             ctx.scene,

--- a/koharu-app/src/pipeline/engines/flux2_klein.rs
+++ b/koharu-app/src/pipeline/engines/flux2_klein.rs
@@ -57,7 +57,7 @@ impl Engine for Model {
             self.0
                 .inpaint_with_reference(&image, &mask, None, &Flux2InpaintOptions::default())?;
         let (w, h) = image_dimensions(&result);
-        let blob = ctx.blobs.put_webp(&result)?;
+        let blob = ctx.blobs.put_image(&result)?;
         Ok(vec![upsert_image_blob(
             ctx.scene,
             ctx.page,

--- a/koharu-app/src/pipeline/engines/lama.rs
+++ b/koharu-app/src/pipeline/engines/lama.rs
@@ -70,7 +70,7 @@ impl Engine for Model {
                 .inference_with_blocks(&image, &mask, &bubble_mask, &text_blocks)?
         };
         let (w, h) = image_dimensions(&result);
-        let blob = ctx.blobs.put_webp(&result)?;
+        let blob = ctx.blobs.put_image(&result)?;
         Ok(vec![upsert_image_blob(
             ctx.scene,
             ctx.page,

--- a/koharu-app/src/pipeline/engines/renderer.rs
+++ b/koharu-app/src/pipeline/engines/renderer.rs
@@ -127,7 +127,7 @@ impl Engine for Model {
         }
 
         // Final composite → Image { Rendered } upsert.
-        let final_blob = ctx.blobs.put_webp(&output.final_render)?;
+        let final_blob = ctx.blobs.put_image(&output.final_render)?;
         ops.push(upsert_image_blob(
             ctx.scene,
             ctx.page,

--- a/koharu-ml/src/anime_text/mod.rs
+++ b/koharu-ml/src/anime_text/mod.rs
@@ -13,7 +13,7 @@ use koharu_runtime::RuntimeManager;
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
 
-use crate::{device, loading, types::TextRegion};
+use crate::{bbox::bbox_is_duplicate, device, loading, slicing::VerticalSlicer, types::TextRegion};
 
 use self::model::{Yolo12, Yolo12Scale};
 
@@ -207,6 +207,20 @@ impl AnimeTextDetector {
         confidence_threshold: f32,
         nms_threshold: f32,
     ) -> Result<AnimeTextDetection> {
+        if let Some(result) =
+            self.inference_sliced_with_thresholds(image, confidence_threshold, nms_threshold)?
+        {
+            return Ok(result);
+        }
+        self.inference_single_with_thresholds(image, confidence_threshold, nms_threshold)
+    }
+
+    fn inference_single_with_thresholds(
+        &self,
+        image: &DynamicImage,
+        confidence_threshold: f32,
+        nms_threshold: f32,
+    ) -> Result<AnimeTextDetection> {
         let started = Instant::now();
         let prepared = self.preprocess(image)?;
         let outputs = self.model.forward(&prepared.pixel_values)?;
@@ -229,6 +243,47 @@ impl AnimeTextDetector {
             regions,
             text_blocks,
         })
+    }
+
+    fn inference_sliced_with_thresholds(
+        &self,
+        image: &DynamicImage,
+        confidence_threshold: f32,
+        nms_threshold: f32,
+    ) -> Result<Option<AnimeTextDetection>> {
+        let Some(slices) = VerticalSlicer::default().slices(image.width(), image.height()) else {
+            return Ok(None);
+        };
+
+        tracing::info!(
+            width = image.width(),
+            height = image.height(),
+            slices = slices.len(),
+            variant = %self.variant,
+            "anime text YOLO slicing tall image"
+        );
+
+        let mut regions = Vec::new();
+        for slice in slices {
+            let cropped = image.crop_imm(0, slice.y, image.width(), slice.height);
+            let mut detection = self.inference_single_with_thresholds(
+                &cropped,
+                confidence_threshold,
+                nms_threshold,
+            )?;
+            offset_anime_regions(&mut detection.regions, slice.y as f32);
+            regions.extend(detection.regions);
+        }
+
+        let regions = dedupe_anime_regions(regions);
+        let text_blocks = regions_to_text_blocks(&regions);
+        Ok(Some(AnimeTextDetection {
+            image_width: image.width(),
+            image_height: image.height(),
+            variant: self.variant,
+            regions,
+            text_blocks,
+        }))
     }
 
     fn preprocess(&self, image: &DynamicImage) -> Result<PreparedInput> {
@@ -276,6 +331,31 @@ impl AnimeTextDetector {
             scale,
         })
     }
+}
+
+fn offset_anime_regions(regions: &mut [AnimeTextRegion], offset_y: f32) {
+    for region in regions {
+        region.bbox[1] += offset_y;
+        region.bbox[3] += offset_y;
+    }
+}
+
+fn dedupe_anime_regions(mut regions: Vec<AnimeTextRegion>) -> Vec<AnimeTextRegion> {
+    regions.sort_by(|a, b| b.score.total_cmp(&a.score));
+    let mut out: Vec<AnimeTextRegion> = Vec::with_capacity(regions.len());
+    for region in regions {
+        if out
+            .iter()
+            .all(|existing| !anime_regions_duplicate(existing, &region))
+        {
+            out.push(region);
+        }
+    }
+    out
+}
+
+fn anime_regions_duplicate(a: &AnimeTextRegion, b: &AnimeTextRegion) -> bool {
+    bbox_is_duplicate(a.bbox, b.bbox)
 }
 
 pub async fn prefetch(runtime: &RuntimeManager) -> Result<()> {

--- a/koharu-ml/src/aot_inpainting/mod.rs
+++ b/koharu-ml/src/aot_inpainting/mod.rs
@@ -15,10 +15,11 @@ use tracing::instrument;
 use crate::{
     device,
     inpainting::{
-        HdStrategyConfig, InpaintForward, apply_bubble_fill, binarize_mask, extract_alpha,
-        restore_alpha_channel, run_inpaint,
+        HdStrategy, HdStrategyConfig, InpaintForward, apply_bubble_fill, binarize_mask,
+        extract_alpha, restore_alpha_channel, run_inpaint,
     },
     loading,
+    slicing::VerticalSlicer,
 };
 
 use self::model::{AotGenerator, AotModelSpec};
@@ -149,7 +150,11 @@ impl AotInpainting {
         mask: &DynamicImage,
         bubble_mask: &DynamicImage,
     ) -> Result<DynamicImage> {
-        self.inference_with_config(image, mask, bubble_mask, &self.default_config())
+        let mut cfg = self.default_config();
+        if is_tall_page(image) {
+            cfg.strategy = HdStrategy::Crop;
+        }
+        self.inference_with_config(image, mask, bubble_mask, &cfg)
     }
 
     #[instrument(level = "debug", skip_all)]
@@ -244,6 +249,11 @@ impl AotInpainting {
         RgbImage::from_raw(width as u32, height as u32, raw)
             .ok_or_else(|| anyhow::anyhow!("failed to create image buffer from model output"))
     }
+}
+
+fn is_tall_page(image: &DynamicImage) -> bool {
+    let (width, height) = image.dimensions();
+    VerticalSlicer::default().is_tall(width, height)
 }
 
 struct AotForward<'a> {

--- a/koharu-ml/src/bbox.rs
+++ b/koharu-ml/src/bbox.rs
@@ -1,0 +1,24 @@
+const CONTAINMENT_DUPLICATE_THRESHOLD: f32 = 0.85;
+const IOU_DUPLICATE_THRESHOLD: f32 = 0.5;
+
+pub(crate) fn bbox_area(bbox: [f32; 4]) -> f32 {
+    (bbox[2] - bbox[0]).max(0.0) * (bbox[3] - bbox[1]).max(0.0)
+}
+
+pub(crate) fn bbox_overlap(a: [f32; 4], b: [f32; 4]) -> f32 {
+    let width = (a[2].min(b[2]) - a[0].max(b[0])).max(0.0);
+    let height = (a[3].min(b[3]) - a[1].max(b[1])).max(0.0);
+    width * height
+}
+
+pub(crate) fn bbox_is_duplicate(a: [f32; 4], b: [f32; 4]) -> bool {
+    let area_a = bbox_area(a);
+    let area_b = bbox_area(b);
+    if area_a <= 0.0 || area_b <= 0.0 {
+        return false;
+    }
+
+    let overlap = bbox_overlap(a, b);
+    overlap / area_a.min(area_b) >= CONTAINMENT_DUPLICATE_THRESHOLD
+        || overlap / (area_a + area_b - overlap).max(1.0) >= IOU_DUPLICATE_THRESHOLD
+}

--- a/koharu-ml/src/comic_text_bubble_detector/mod.rs
+++ b/koharu-ml/src/comic_text_bubble_detector/mod.rs
@@ -9,13 +9,14 @@ use koharu_runtime::RuntimeManager;
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
 
-use crate::{Device, device, loading, types::TextRegion};
+use crate::{Device, device, loading, slicing::VerticalSlicer, types::TextRegion};
 
 use self::model::{RTDetrV2ForObjectDetection, RTDetrV2Outputs};
 
 const HF_REPO: &str = "ogkalu/comic-text-and-bubble-detector";
 const DEFAULT_CONFIDENCE_THRESHOLD: f32 = 0.3;
 const DETECTOR_NAME: &str = "comic-text-bubble-detector";
+const BUBBLE_DETECTOR_TARGET_SLICE_RATIO: f32 = 3.0;
 
 koharu_runtime::declare_hf_model_package!(
     id: "model:comic-text-bubble-detector:config",
@@ -46,7 +47,6 @@ pub struct ComicTextBubbleDetector {
     preprocessor: RTDetrImageProcessorConfig,
     device: Device,
     dtype: DType,
-    slicer: ImageSlicer,
 }
 
 impl ComicTextBubbleDetector {
@@ -80,7 +80,6 @@ impl ComicTextBubbleDetector {
             preprocessor,
             device,
             dtype,
-            slicer: ImageSlicer::default(),
         })
     }
 
@@ -96,9 +95,7 @@ impl ComicTextBubbleDetector {
         threshold: f32,
     ) -> Result<ComicTextBubbleDetection> {
         let started = Instant::now();
-        let detections = self.slicer.process_slices_for_detection(image, |slice| {
-            self.detect_single_image(slice, threshold)
-        })?;
+        let detections = self.detect_sliced_or_single(image, threshold)?;
         let detections = merge_slice_regions(
             filter_and_fix_regions(detections, image.dimensions()),
             image.height(),
@@ -120,6 +117,41 @@ impl ComicTextBubbleDetector {
             detections,
             text_blocks,
         })
+    }
+
+    #[instrument(level = "debug", skip_all)]
+    fn detect_sliced_or_single(
+        &self,
+        image: &DynamicImage,
+        threshold: f32,
+    ) -> Result<Vec<ComicTextBubbleRegion>> {
+        let slicer = VerticalSlicer {
+            target_slice_ratio: BUBBLE_DETECTOR_TARGET_SLICE_RATIO,
+            ..VerticalSlicer::default()
+        };
+        let Some(slices) = slicer.slices(image.width(), image.height()) else {
+            return self.detect_single_image(image, threshold);
+        };
+
+        tracing::info!(
+            width = image.width(),
+            height = image.height(),
+            slices = slices.len(),
+            "comic text bubble detector slicing tall image"
+        );
+
+        let mut detections = Vec::new();
+        for slice in slices {
+            let cropped = image.crop_imm(0, slice.y, image.width(), slice.height);
+            let mut slice_detections = self.detect_single_image(&cropped, threshold)?;
+            for detection in &mut slice_detections {
+                detection.bbox[1] += slice.y as f32;
+                detection.bbox[3] += slice.y as f32;
+            }
+            detections.extend(slice_detections);
+        }
+
+        Ok(detections)
     }
 
     #[instrument(level = "debug", skip_all)]
@@ -727,83 +759,6 @@ fn merge_boxes(box1: [f32; 4], box2: [f32; 4]) -> [f32; 4] {
         box1[2].max(box2[2]),
         box1[3].max(box2[3]),
     ]
-}
-
-#[derive(Debug, Clone)]
-struct ImageSlicer {
-    height_to_width_ratio_threshold: f32,
-    target_slice_ratio: f32,
-    overlap_height_ratio: f32,
-    min_slice_height_ratio: f32,
-}
-
-impl Default for ImageSlicer {
-    fn default() -> Self {
-        Self {
-            height_to_width_ratio_threshold: 3.5,
-            target_slice_ratio: 3.0,
-            overlap_height_ratio: 0.2,
-            min_slice_height_ratio: 0.7,
-        }
-    }
-}
-
-impl ImageSlicer {
-    fn should_slice(&self, image: &DynamicImage) -> bool {
-        let (width, height) = image.dimensions();
-        height as f32 / width.max(1) as f32 > self.height_to_width_ratio_threshold
-    }
-
-    fn calculate_slice_params(&self, image: &DynamicImage) -> (u32, u32, usize) {
-        let (width, height) = image.dimensions();
-        let slice_height = (width as f32 * self.target_slice_ratio).round().max(1.0) as u32;
-        let effective_slice_height = (slice_height as f32 * (1.0 - self.overlap_height_ratio))
-            .round()
-            .max(1.0) as u32;
-        let mut num_slices = height.div_ceil(effective_slice_height) as usize;
-        if num_slices > 1 {
-            let last_slice_start = (num_slices as u32 - 1) * effective_slice_height;
-            let last_slice_height = height.saturating_sub(last_slice_start);
-            if last_slice_height as f32 / slice_height as f32 <= self.min_slice_height_ratio {
-                num_slices -= 1;
-            }
-        }
-        (slice_height, effective_slice_height, num_slices.max(1))
-    }
-
-    fn process_slices_for_detection<F>(
-        &self,
-        image: &DynamicImage,
-        detect_fn: F,
-    ) -> Result<Vec<ComicTextBubbleRegion>>
-    where
-        F: Fn(&DynamicImage) -> Result<Vec<ComicTextBubbleRegion>>,
-    {
-        if !self.should_slice(image) {
-            return detect_fn(image);
-        }
-
-        let (slice_height, effective_slice_height, num_slices) = self.calculate_slice_params(image);
-        let (width, height) = image.dimensions();
-        let mut detections = Vec::new();
-        for slice_number in 0..num_slices {
-            let start_y = slice_number as u32 * effective_slice_height;
-            let end_y = if slice_number + 1 == num_slices {
-                height
-            } else {
-                (start_y + slice_height).min(height)
-            };
-            let crop_height = end_y.saturating_sub(start_y).max(1);
-            let cropped = image.crop_imm(0, start_y, width, crop_height);
-            let mut slice_detections = detect_fn(&cropped)?;
-            for detection in &mut slice_detections {
-                detection.bbox[1] += start_y as f32;
-                detection.bbox[3] += start_y as f32;
-            }
-            detections.extend(slice_detections);
-        }
-        Ok(detections)
-    }
 }
 
 const fn default_true() -> bool {

--- a/koharu-ml/src/comic_text_detector/mod.rs
+++ b/koharu-ml/src/comic_text_detector/mod.rs
@@ -12,7 +12,7 @@ use image::{DynamicImage, GenericImageView, GrayImage};
 use koharu_runtime::RuntimeManager;
 use tracing::instrument;
 
-use crate::{device, loading, types::TextRegion};
+use crate::{bbox::bbox_is_duplicate, device, loading, slicing::VerticalSlicer, types::TextRegion};
 
 pub use postprocess::{
     ComicTextDetection, Quad, crop_text_block_bbox, expanded_text_block_crop_bounds,
@@ -121,6 +121,13 @@ impl ComicTextDetector {
 
     #[instrument(level = "debug", skip_all)]
     pub fn inference(&self, image: &DynamicImage) -> anyhow::Result<ComicTextDetection> {
+        if let Some(result) = self.inference_sliced(image)? {
+            return Ok(result);
+        }
+        self.inference_single(image)
+    }
+
+    fn inference_single(&self, image: &DynamicImage) -> anyhow::Result<ComicTextDetection> {
         let original_dimensions = image.dimensions();
         let (image_tensor, resized_dimensions) = preprocess(image, &self.device, self.dtype)?;
         let (predictions, mask, shrink_threshold) = self.forward(&image_tensor)?;
@@ -154,10 +161,82 @@ impl ComicTextDetector {
 
     #[instrument(level = "debug", skip_all)]
     pub fn inference_segmentation(&self, image: &DynamicImage) -> anyhow::Result<GrayImage> {
+        if let Some(mask) = self.inference_segmentation_sliced(image)? {
+            return Ok(mask);
+        }
+        self.inference_segmentation_single(image)
+    }
+
+    fn inference_segmentation_single(&self, image: &DynamicImage) -> anyhow::Result<GrayImage> {
         let original_dimensions = image.dimensions();
         let (image_tensor, resized_dimensions) = preprocess(image, &self.device, self.dtype)?;
         let mask = self.forward_mask(&image_tensor)?;
         postprocess_unet_mask(&mask, original_dimensions, resized_dimensions)
+    }
+
+    fn inference_sliced(&self, image: &DynamicImage) -> anyhow::Result<Option<ComicTextDetection>> {
+        let Some(slices) = VerticalSlicer::default().slices(image.width(), image.height()) else {
+            return Ok(None);
+        };
+
+        tracing::info!(
+            width = image.width(),
+            height = image.height(),
+            slices = slices.len(),
+            "comic text detector slicing tall image"
+        );
+
+        let mut shrink_map = GrayImage::new(image.width(), image.height());
+        let mut threshold_map = GrayImage::new(image.width(), image.height());
+        let mut mask = GrayImage::new(image.width(), image.height());
+        let mut line_polygons = Vec::new();
+        let mut text_blocks = Vec::new();
+
+        for slice in slices {
+            let cropped = image.crop_imm(0, slice.y, image.width(), slice.height);
+            let mut detection = self.inference_single(&cropped)?;
+            offset_quads(&mut detection.line_polygons, slice.y as f32);
+            for block in &mut detection.text_blocks {
+                offset_text_region(block, slice.y as f32);
+            }
+            line_polygons.extend(detection.line_polygons);
+            text_blocks.extend(detection.text_blocks);
+            stitch_gray_max(&mut shrink_map, &detection.shrink_map, slice.y);
+            stitch_gray_max(&mut threshold_map, &detection.threshold_map, slice.y);
+            stitch_gray_max(&mut mask, &detection.mask, slice.y);
+        }
+
+        Ok(Some(ComicTextDetection {
+            shrink_map,
+            threshold_map,
+            line_polygons,
+            text_blocks: dedupe_text_blocks(text_blocks),
+            mask,
+        }))
+    }
+
+    fn inference_segmentation_sliced(
+        &self,
+        image: &DynamicImage,
+    ) -> anyhow::Result<Option<GrayImage>> {
+        let Some(slices) = VerticalSlicer::default().slices(image.width(), image.height()) else {
+            return Ok(None);
+        };
+
+        tracing::info!(
+            width = image.width(),
+            height = image.height(),
+            slices = slices.len(),
+            "comic text detector segmenting tall image in slices"
+        );
+
+        let mut output = GrayImage::new(image.width(), image.height());
+        for slice in slices {
+            let cropped = image.crop_imm(0, slice.y, image.width(), slice.height);
+            let mask = self.inference_segmentation_single(&cropped)?;
+            stitch_gray_max(&mut output, &mask, slice.y);
+        }
+        Ok(Some(output))
     }
 
     #[instrument(level = "debug", skip_all)]
@@ -191,6 +270,66 @@ impl ComicTextDetector {
         )?;
         Ok(mask)
     }
+}
+
+fn stitch_gray_max(dst: &mut GrayImage, src: &GrayImage, dst_y: u32) {
+    let width = dst.width().min(src.width());
+    let height = src.height().min(dst.height().saturating_sub(dst_y));
+    let dst_width = dst.width() as usize;
+    let src_width = src.width() as usize;
+    let width = width as usize;
+    let dst = dst.as_mut();
+    let src = src.as_raw();
+    for y in 0..height as usize {
+        let dst_row = (dst_y as usize + y) * dst_width;
+        let src_row = y * src_width;
+        for x in 0..width {
+            let value = src[src_row + x];
+            let target = &mut dst[dst_row + x];
+            if value > *target {
+                *target = value;
+            }
+        }
+    }
+}
+
+fn offset_text_region(region: &mut TextRegion, offset_y: f32) {
+    region.y += offset_y;
+    if let Some(lines) = region.line_polygons.as_mut() {
+        for line in lines {
+            for point in line {
+                point[1] += offset_y;
+            }
+        }
+    }
+}
+
+fn offset_quads(quads: &mut [Quad], offset_y: f32) {
+    for quad in quads {
+        for point in quad {
+            point[1] += offset_y;
+        }
+    }
+}
+
+fn dedupe_text_blocks(mut blocks: Vec<TextRegion>) -> Vec<TextRegion> {
+    blocks.sort_by(|a, b| b.confidence.total_cmp(&a.confidence));
+    let mut out: Vec<TextRegion> = Vec::with_capacity(blocks.len());
+    for block in blocks {
+        if out
+            .iter()
+            .all(|existing| !text_regions_duplicate(existing, &block))
+        {
+            out.push(block);
+        }
+    }
+    out
+}
+
+fn text_regions_duplicate(a: &TextRegion, b: &TextRegion) -> bool {
+    let a_bbox = [a.x, a.y, a.x + a.width, a.y + a.height];
+    let b_bbox = [b.x, b.y, b.x + b.width, b.y + b.height];
+    bbox_is_duplicate(a_bbox, b_bbox)
 }
 
 #[instrument(level = "debug", skip_all)]

--- a/koharu-ml/src/comic_text_detector/mod.rs
+++ b/koharu-ml/src/comic_text_detector/mod.rs
@@ -201,15 +201,15 @@ impl ComicTextDetector {
             }
             line_polygons.extend(detection.line_polygons);
             text_blocks.extend(detection.text_blocks);
-            stitch_gray_max(&mut shrink_map, &detection.shrink_map, slice.y);
-            stitch_gray_max(&mut threshold_map, &detection.threshold_map, slice.y);
-            stitch_gray_max(&mut mask, &detection.mask, slice.y);
+            stitch_gray_max(&mut shrink_map, &detection.shrink_map, slice.y)?;
+            stitch_gray_max(&mut threshold_map, &detection.threshold_map, slice.y)?;
+            stitch_gray_max(&mut mask, &detection.mask, slice.y)?;
         }
 
         Ok(Some(ComicTextDetection {
             shrink_map,
             threshold_map,
-            line_polygons,
+            line_polygons: dedupe_quads(line_polygons),
             text_blocks: dedupe_text_blocks(text_blocks),
             mask,
         }))
@@ -234,7 +234,7 @@ impl ComicTextDetector {
         for slice in slices {
             let cropped = image.crop_imm(0, slice.y, image.width(), slice.height);
             let mask = self.inference_segmentation_single(&cropped)?;
-            stitch_gray_max(&mut output, &mask, slice.y);
+            stitch_gray_max(&mut output, &mask, slice.y)?;
         }
         Ok(Some(output))
     }
@@ -272,8 +272,23 @@ impl ComicTextDetector {
     }
 }
 
-fn stitch_gray_max(dst: &mut GrayImage, src: &GrayImage, dst_y: u32) {
-    let width = dst.width().min(src.width());
+fn stitch_gray_max(dst: &mut GrayImage, src: &GrayImage, dst_y: u32) -> anyhow::Result<()> {
+    if dst.width() != src.width() {
+        bail!(
+            "cannot stitch gray maps with different widths: {} vs {}",
+            dst.width(),
+            src.width()
+        );
+    }
+    if dst_y >= dst.height() {
+        bail!(
+            "cannot stitch gray map at y={} into height {}",
+            dst_y,
+            dst.height()
+        );
+    }
+
+    let width = dst.width();
     let height = src.height().min(dst.height().saturating_sub(dst_y));
     let dst_width = dst.width() as usize;
     let src_width = src.width() as usize;
@@ -291,6 +306,7 @@ fn stitch_gray_max(dst: &mut GrayImage, src: &GrayImage, dst_y: u32) {
             }
         }
     }
+    Ok(())
 }
 
 fn offset_text_region(region: &mut TextRegion, offset_y: f32) {
@@ -324,6 +340,33 @@ fn dedupe_text_blocks(mut blocks: Vec<TextRegion>) -> Vec<TextRegion> {
         }
     }
     out
+}
+
+fn dedupe_quads(quads: Vec<Quad>) -> Vec<Quad> {
+    let mut out: Vec<Quad> = Vec::with_capacity(quads.len());
+    for quad in quads {
+        if out
+            .iter()
+            .all(|existing| !bbox_is_duplicate(quad_bbox(existing), quad_bbox(&quad)))
+        {
+            out.push(quad);
+        }
+    }
+    out
+}
+
+fn quad_bbox(quad: &Quad) -> [f32; 4] {
+    let mut min_x = f32::INFINITY;
+    let mut min_y = f32::INFINITY;
+    let mut max_x = f32::NEG_INFINITY;
+    let mut max_y = f32::NEG_INFINITY;
+    for [x, y] in quad {
+        min_x = min_x.min(*x);
+        min_y = min_y.min(*y);
+        max_x = max_x.max(*x);
+        max_y = max_y.max(*y);
+    }
+    [min_x, min_y, max_x, max_y]
 }
 
 fn text_regions_duplicate(a: &TextRegion, b: &TextRegion) -> bool {

--- a/koharu-ml/src/flux2_klein/mod.rs
+++ b/koharu-ml/src/flux2_klein/mod.rs
@@ -363,7 +363,7 @@ impl Flux2Klein {
                 continue;
             }
 
-            let image_crop = image.crop_imm(0, slice.y, image.width(), slice.height);
+            let image_crop = output.crop_imm(0, slice.y, image.width(), slice.height);
             let reference_crop = reference_image
                 .filter(|reference| reference.dimensions() == image.dimensions())
                 .map(|reference| reference.crop_imm(0, slice.y, image.width(), slice.height));

--- a/koharu-ml/src/flux2_klein/mod.rs
+++ b/koharu-ml/src/flux2_klein/mod.rs
@@ -13,7 +13,10 @@ use image::{DynamicImage, GenericImageView, RgbImage};
 use koharu_runtime::RuntimeManager;
 use tracing::instrument;
 
-use crate::{device, inpainting, loading};
+use crate::{
+    device, inpainting, loading,
+    slicing::{VerticalSlice, VerticalSlicer},
+};
 
 use self::{
     latents::{
@@ -315,6 +318,12 @@ impl Flux2Klein {
             return Ok(image.clone());
         }
 
+        if let Some(output) =
+            self.inpaint_tall_page_sliced(image, mask, reference_image, options)?
+        {
+            return Ok(output);
+        }
+
         if let Some(bounds) = inpaint_crop_bounds(image, mask, options.mask_padding) {
             let image_crop = image.crop_imm(bounds.x, bounds.y, bounds.width, bounds.height);
             let mask_crop = mask.crop_imm(bounds.x, bounds.y, bounds.width, bounds.height);
@@ -324,6 +333,65 @@ impl Flux2Klein {
         }
 
         self.inpaint_full_frame(image, mask, reference_image, options)
+    }
+
+    fn inpaint_tall_page_sliced(
+        &self,
+        image: &DynamicImage,
+        mask: &DynamicImage,
+        reference_image: Option<&DynamicImage>,
+        options: &Flux2InpaintOptions,
+    ) -> Result<Option<DynamicImage>> {
+        let Some(slices) = VerticalSlicer::default().slices(image.width(), image.height()) else {
+            return Ok(None);
+        };
+
+        tracing::info!(
+            width = image.width(),
+            height = image.height(),
+            slices = slices.len(),
+            "flux2 inpainting slicing tall image"
+        );
+
+        let mut output = image.clone();
+        let mut processed_slices = 0usize;
+        let mut previous_end_y = 0u32;
+        for slice in slices {
+            let mask_crop = non_overlapping_slice_mask(mask, image.width(), slice, previous_end_y);
+            previous_end_y = previous_end_y.max(slice.y.saturating_add(slice.height));
+            if !mask_has_nonzero(&mask_crop) {
+                continue;
+            }
+
+            let image_crop = image.crop_imm(0, slice.y, image.width(), slice.height);
+            let reference_crop = reference_image
+                .filter(|reference| reference.dimensions() == image.dimensions())
+                .map(|reference| reference.crop_imm(0, slice.y, image.width(), slice.height));
+            let generated = self.inpaint_with_reference(
+                &image_crop,
+                &mask_crop,
+                reference_crop.as_ref(),
+                options,
+            )?;
+            output = composite_inpaint_crop(
+                &output,
+                &generated,
+                &mask_crop,
+                CropBounds {
+                    x: 0,
+                    y: slice.y,
+                    width: image.width(),
+                    height: slice.height,
+                },
+            )?;
+            processed_slices += 1;
+        }
+
+        if processed_slices == 0 {
+            return Ok(None);
+        }
+
+        Ok(Some(output))
     }
 
     fn inpaint_full_frame(
@@ -591,6 +659,26 @@ fn inpaint_crop_bounds(
     })
 }
 
+fn mask_has_nonzero(mask: &DynamicImage) -> bool {
+    mask.to_luma8().pixels().any(|pixel| pixel.0[0] > 0)
+}
+
+fn non_overlapping_slice_mask(
+    mask: &DynamicImage,
+    width: u32,
+    slice: VerticalSlice,
+    previous_end_y: u32,
+) -> DynamicImage {
+    let mut mask_crop = mask.crop_imm(0, slice.y, width, slice.height).to_luma8();
+    let overlap_height = previous_end_y.saturating_sub(slice.y).min(slice.height);
+    for y in 0..overlap_height {
+        for x in 0..mask_crop.width() {
+            mask_crop.get_pixel_mut(x, y).0[0] = 0;
+        }
+    }
+    DynamicImage::ImageLuma8(mask_crop)
+}
+
 fn composite_inpaint_crop(
     original: &DynamicImage,
     generated_crop: &DynamicImage,
@@ -655,4 +743,37 @@ fn restore_original_alpha(output: DynamicImage, original: &DynamicImage) -> Dyna
         pixel.0[3] = alpha.get_pixel(x, y).0[0];
     }
     DynamicImage::ImageRgba8(rgba)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{mask_has_nonzero, non_overlapping_slice_mask};
+    use crate::slicing::VerticalSlice;
+    use image::{DynamicImage, GrayImage, Luma};
+
+    #[test]
+    fn mask_has_nonzero_detects_any_painted_pixel() {
+        let mut mask = GrayImage::new(2, 2);
+        assert!(!mask_has_nonzero(&DynamicImage::ImageLuma8(mask.clone())));
+
+        mask.put_pixel(1, 1, Luma([255]));
+
+        assert!(mask_has_nonzero(&DynamicImage::ImageLuma8(mask)));
+    }
+
+    #[test]
+    fn non_overlapping_slice_mask_clears_previous_overlap() {
+        let mask = GrayImage::from_pixel(2, 4, Luma([255]));
+        let mask = non_overlapping_slice_mask(
+            &DynamicImage::ImageLuma8(mask),
+            2,
+            VerticalSlice { y: 1, height: 3 },
+            3,
+        )
+        .to_luma8();
+
+        assert_eq!(mask.get_pixel(0, 0).0[0], 0);
+        assert_eq!(mask.get_pixel(0, 1).0[0], 0);
+        assert_eq!(mask.get_pixel(0, 2).0[0], 255);
+    }
 }

--- a/koharu-ml/src/lib.rs
+++ b/koharu-ml/src/lib.rs
@@ -1,4 +1,6 @@
+mod bbox;
 mod hf_hub;
+mod slicing;
 
 pub mod anime_text;
 pub mod aot_inpainting;

--- a/koharu-ml/src/manga_text_segmentation_2025/mod.rs
+++ b/koharu-ml/src/manga_text_segmentation_2025/mod.rs
@@ -11,7 +11,7 @@ use candle_nn::ops::sigmoid;
 use image::{DynamicImage, imageops::FilterType};
 use koharu_runtime::RuntimeManager;
 
-use crate::{device, loading, probability_map::ProbabilityMap};
+use crate::{device, loading, probability_map::ProbabilityMap, slicing::VerticalSlicer};
 
 const REPO: &str = "mayocream/manga-text-segmentation-2025";
 const SAFETENSORS_FILENAME: &str = "model.safetensors";
@@ -64,6 +64,13 @@ impl MangaTextSegmentation {
     }
 
     pub fn inference(&self, image: &DynamicImage) -> Result<ProbabilityMap> {
+        if let Some(result) = self.inference_sliced(image)? {
+            return Ok(result);
+        }
+        self.inference_single(image)
+    }
+
+    fn inference_single(&self, image: &DynamicImage) -> Result<ProbabilityMap> {
         let started = Instant::now();
         let preprocess_started = Instant::now();
         let prepared = self.preprocess(image)?;
@@ -114,6 +121,28 @@ impl MangaTextSegmentation {
             height: prepared.original_height,
             values,
         })
+    }
+
+    fn inference_sliced(&self, image: &DynamicImage) -> Result<Option<ProbabilityMap>> {
+        let Some(slices) = VerticalSlicer::default().slices(image.width(), image.height()) else {
+            return Ok(None);
+        };
+
+        tracing::info!(
+            width = image.width(),
+            height = image.height(),
+            slices = slices.len(),
+            "manga text segmentation slicing tall image"
+        );
+
+        let mut output = ProbabilityMap::zeros(image.width(), image.height());
+        for slice in slices {
+            let cropped = image.crop_imm(0, slice.y, image.width(), slice.height);
+            let probability_map = self.inference_single(&cropped)?;
+            output.stitch_max(&probability_map, slice.y)?;
+        }
+
+        Ok(Some(output))
     }
 
     fn preprocess(&self, image: &DynamicImage) -> Result<PreparedInput> {

--- a/koharu-ml/src/pp_doclayout_v3/mod.rs
+++ b/koharu-ml/src/pp_doclayout_v3/mod.rs
@@ -12,7 +12,7 @@ use imageproc::contours::{BorderType, find_contours};
 use koharu_runtime::RuntimeManager;
 use serde::{Deserialize, Serialize};
 
-use crate::{device, loading};
+use crate::{bbox::bbox_is_duplicate, device, loading, slicing::VerticalSlicer};
 
 use self::model::{PPDocLayoutV3ForObjectDetection, PPDocLayoutV3Outputs};
 
@@ -163,10 +163,7 @@ impl PPDocLayoutV3 {
         image: &DynamicImage,
         threshold: f32,
     ) -> Result<LayoutDetectionResult> {
-        let mut results = self.inference(std::slice::from_ref(image), threshold)?;
-        results
-            .pop()
-            .ok_or_else(|| anyhow::anyhow!("missing layout result"))
+        self.inference_one_impl(image, threshold, true)
     }
 
     pub fn inference_one_fast(
@@ -174,10 +171,70 @@ impl PPDocLayoutV3 {
         image: &DynamicImage,
         threshold: f32,
     ) -> Result<LayoutDetectionResult> {
-        let mut results = self.inference_fast(std::slice::from_ref(image), threshold)?;
+        self.inference_one_impl(image, threshold, false)
+    }
+
+    fn inference_one_impl(
+        &self,
+        image: &DynamicImage,
+        threshold: f32,
+        include_polygons: bool,
+    ) -> Result<LayoutDetectionResult> {
+        if let Some(result) = self.inference_one_sliced(image, threshold, include_polygons)? {
+            return Ok(result);
+        }
+
+        let mut results =
+            self.inference_impl(std::slice::from_ref(image), threshold, include_polygons)?;
         results
             .pop()
             .ok_or_else(|| anyhow::anyhow!("missing layout result"))
+    }
+
+    fn inference_one_sliced(
+        &self,
+        image: &DynamicImage,
+        threshold: f32,
+        include_polygons: bool,
+    ) -> Result<Option<LayoutDetectionResult>> {
+        let Some(slices) = VerticalSlicer::default().slices(image.width(), image.height()) else {
+            return Ok(None);
+        };
+
+        tracing::info!(
+            width = image.width(),
+            height = image.height(),
+            slices = slices.len(),
+            include_polygons,
+            "pp-doclayout-v3 slicing tall image"
+        );
+
+        let mut regions = Vec::new();
+        for slice in slices {
+            let cropped = image.crop_imm(0, slice.y, image.width(), slice.height);
+            let mut result = self
+                .inference_impl(std::slice::from_ref(&cropped), threshold, include_polygons)?
+                .pop()
+                .ok_or_else(|| anyhow::anyhow!("missing layout slice result"))?;
+            offset_layout_regions(&mut result.regions, slice.y as f32);
+            regions.extend(result.regions);
+        }
+
+        let mut regions = dedupe_layout_regions(regions);
+        regions.sort_by(|a, b| {
+            a.bbox[1]
+                .total_cmp(&b.bbox[1])
+                .then_with(|| a.bbox[0].total_cmp(&b.bbox[0]))
+        });
+        for (order, region) in regions.iter_mut().enumerate() {
+            region.order = order;
+        }
+
+        Ok(Some(LayoutDetectionResult {
+            image_width: image.width(),
+            image_height: image.height(),
+            regions,
+        }))
     }
 }
 
@@ -198,6 +255,37 @@ pub struct LayoutRegion {
     pub score: f32,
     pub bbox: [f32; 4],
     pub polygon_points: Vec<[f32; 2]>,
+}
+
+fn offset_layout_regions(regions: &mut [LayoutRegion], offset_y: f32) {
+    for region in regions {
+        region.bbox[1] += offset_y;
+        region.bbox[3] += offset_y;
+        for point in &mut region.polygon_points {
+            point[1] += offset_y;
+        }
+    }
+}
+
+fn dedupe_layout_regions(mut regions: Vec<LayoutRegion>) -> Vec<LayoutRegion> {
+    regions.sort_by(|a, b| b.score.total_cmp(&a.score));
+    let mut out: Vec<LayoutRegion> = Vec::with_capacity(regions.len());
+    for region in regions {
+        if out
+            .iter()
+            .all(|existing| !layout_regions_duplicate(existing, &region))
+        {
+            out.push(region);
+        }
+    }
+    out
+}
+
+fn layout_regions_duplicate(a: &LayoutRegion, b: &LayoutRegion) -> bool {
+    if a.label_id != b.label_id {
+        return false;
+    }
+    bbox_is_duplicate(a.bbox, b.bbox)
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/koharu-ml/src/probability_map.rs
+++ b/koharu-ml/src/probability_map.rs
@@ -50,6 +50,13 @@ impl ProbabilityMap {
                 src.width
             );
         }
+        if dst_y >= self.height {
+            bail!(
+                "cannot stitch probability map at y={} into height {}",
+                dst_y,
+                self.height
+            );
+        }
 
         let height = src.height.min(self.height.saturating_sub(dst_y));
         let width = self.width as usize;

--- a/koharu-ml/src/probability_map.rs
+++ b/koharu-ml/src/probability_map.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use image::GrayImage;
 
 #[derive(Debug, Clone)]
@@ -40,5 +40,51 @@ impl ProbabilityMap {
 
     pub fn max_value(&self) -> f32 {
         self.values.iter().copied().fold(0.0, f32::max)
+    }
+
+    pub fn stitch_max(&mut self, src: &ProbabilityMap, dst_y: u32) -> Result<()> {
+        if self.width != src.width {
+            bail!(
+                "cannot stitch probability maps with different widths: {} vs {}",
+                self.width,
+                src.width
+            );
+        }
+
+        let height = src.height.min(self.height.saturating_sub(dst_y));
+        let width = self.width as usize;
+        for y in 0..height as usize {
+            let dst_row = (dst_y as usize + y) * width;
+            let src_row = y * width;
+            for x in 0..width {
+                let src_value = src.values[src_row + x];
+                let dst_value = &mut self.values[dst_row + x];
+                if src_value > *dst_value {
+                    *dst_value = src_value;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ProbabilityMap;
+
+    #[test]
+    fn stitch_max_uses_max_blend() -> anyhow::Result<()> {
+        let mut dst = ProbabilityMap::zeros(2, 4);
+        let src = ProbabilityMap {
+            width: 2,
+            height: 2,
+            values: vec![0.1, 0.8, 0.4, 0.2],
+        };
+        dst.values[2] = 0.9;
+
+        dst.stitch_max(&src, 1)?;
+
+        assert_eq!(dst.values, vec![0.0, 0.0, 0.9, 0.8, 0.4, 0.2, 0.0, 0.0]);
+        Ok(())
     }
 }

--- a/koharu-ml/src/slicing.rs
+++ b/koharu-ml/src/slicing.rs
@@ -31,7 +31,8 @@ impl VerticalSlicer {
     }
 
     /// Returns vertical slices only when the image is tall enough and splitting
-    /// would produce more than one useful slice after short-tail trimming.
+    /// would produce more than one useful slice after short-tail trimming. Very
+    /// narrow images use `MIN_SLICE_HEIGHT` instead of the configured ratio.
     pub(crate) fn slices(self, width: u32, height: u32) -> Option<Vec<VerticalSlice>> {
         if !self.is_tall(width, height) {
             return None;

--- a/koharu-ml/src/slicing.rs
+++ b/koharu-ml/src/slicing.rs
@@ -1,0 +1,111 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct VerticalSlice {
+    pub y: u32,
+    pub height: u32,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct VerticalSlicer {
+    pub aspect_ratio_threshold: f32,
+    pub target_slice_ratio: f32,
+    pub overlap_height_ratio: f32,
+    pub min_last_slice_ratio: f32,
+}
+
+const MIN_SLICE_HEIGHT: u32 = 256;
+
+impl Default for VerticalSlicer {
+    fn default() -> Self {
+        Self {
+            aspect_ratio_threshold: 3.5,
+            target_slice_ratio: 2.0,
+            overlap_height_ratio: 0.2,
+            min_last_slice_ratio: 0.7,
+        }
+    }
+}
+
+impl VerticalSlicer {
+    pub(crate) fn is_tall(self, width: u32, height: u32) -> bool {
+        width > 0 && height > 0 && height as f32 / width as f32 > self.aspect_ratio_threshold
+    }
+
+    /// Returns vertical slices only when the image is tall enough and splitting
+    /// would produce more than one useful slice after short-tail trimming.
+    pub(crate) fn slices(self, width: u32, height: u32) -> Option<Vec<VerticalSlice>> {
+        if !self.is_tall(width, height) {
+            return None;
+        }
+
+        let slice_height = (width as f32 * self.target_slice_ratio)
+            .round()
+            .max(MIN_SLICE_HEIGHT as f32) as u32;
+        if slice_height >= height {
+            return None;
+        }
+
+        let effective_slice_height = (slice_height as f32 * (1.0 - self.overlap_height_ratio))
+            .round()
+            .max(1.0) as u32;
+        let mut num_slices = height.div_ceil(effective_slice_height) as usize;
+        if num_slices > 1 {
+            let last_slice_start = (num_slices as u32 - 1) * effective_slice_height;
+            let last_slice_height = height.saturating_sub(last_slice_start);
+            if last_slice_height as f32 / slice_height as f32 <= self.min_last_slice_ratio {
+                num_slices -= 1;
+            }
+        }
+
+        debug_assert!(num_slices >= 1);
+
+        let mut slices = Vec::with_capacity(num_slices);
+        for slice_number in 0..num_slices {
+            let start_y = slice_number as u32 * effective_slice_height;
+            if start_y >= height {
+                break;
+            }
+            let end_y = if slice_number + 1 == num_slices {
+                height
+            } else {
+                (start_y + slice_height).min(height)
+            };
+            let crop_height = end_y.saturating_sub(start_y);
+            if crop_height > 0 {
+                slices.push(VerticalSlice {
+                    y: start_y,
+                    height: crop_height,
+                });
+            }
+        }
+
+        (slices.len() > 1).then_some(slices)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{VerticalSlice, VerticalSlicer};
+
+    #[test]
+    fn slices_only_very_tall_images() {
+        let slicer = VerticalSlicer::default();
+
+        assert!(slicer.slices(1000, 2000).is_none());
+        assert!(slicer.slices(1000, 5000).is_some());
+    }
+
+    #[test]
+    fn slices_overlap_and_cover_full_height() {
+        let slicer = VerticalSlicer::default();
+        let slices = slicer.slices(100, 1000).expect("tall image");
+
+        assert_eq!(slices[0], VerticalSlice { y: 0, height: 256 });
+        assert_eq!(
+            slices.last().unwrap().y + slices.last().unwrap().height,
+            1000
+        );
+        for pair in slices.windows(2) {
+            assert!(pair[0].y + pair[0].height > pair[1].y);
+        }
+    }
+}

--- a/koharu-ml/src/speech_bubble_segmentation/mod.rs
+++ b/koharu-ml/src/speech_bubble_segmentation/mod.rs
@@ -17,7 +17,10 @@ use koharu_runtime::RuntimeManager;
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
 
-use crate::{device, loading, probability_map::ProbabilityMap};
+use crate::{
+    bbox::bbox_is_duplicate, device, loading, probability_map::ProbabilityMap,
+    slicing::VerticalSlicer,
+};
 
 use self::model::{Multiples, YoloV8Seg, YoloV8SegOutputs};
 
@@ -221,6 +224,20 @@ impl SpeechBubbleSegmentation {
         confidence_threshold: f32,
         nms_threshold: f32,
     ) -> Result<SpeechBubbleSegmentationResult> {
+        if let Some(result) =
+            self.inference_sliced_with_thresholds(image, confidence_threshold, nms_threshold)?
+        {
+            return Ok(result);
+        }
+        self.inference_single_with_thresholds(image, confidence_threshold, nms_threshold)
+    }
+
+    fn inference_single_with_thresholds(
+        &self,
+        image: &DynamicImage,
+        confidence_threshold: f32,
+        nms_threshold: f32,
+    ) -> Result<SpeechBubbleSegmentationResult> {
         let started = Instant::now();
         let preprocess_started = Instant::now();
         let prepared = self.preprocess(image)?;
@@ -254,6 +271,46 @@ impl SpeechBubbleSegmentation {
         );
 
         Ok(result)
+    }
+
+    fn inference_sliced_with_thresholds(
+        &self,
+        image: &DynamicImage,
+        confidence_threshold: f32,
+        nms_threshold: f32,
+    ) -> Result<Option<SpeechBubbleSegmentationResult>> {
+        let Some(slices) = VerticalSlicer::default().slices(image.width(), image.height()) else {
+            return Ok(None);
+        };
+
+        tracing::info!(
+            width = image.width(),
+            height = image.height(),
+            slices = slices.len(),
+            "speech bubble segmentation slicing tall image"
+        );
+
+        let mut probability_map = ProbabilityMap::zeros(image.width(), image.height());
+        let mut regions = Vec::new();
+
+        for slice in slices {
+            let cropped = image.crop_imm(0, slice.y, image.width(), slice.height);
+            let mut result = self.inference_single_with_thresholds(
+                &cropped,
+                confidence_threshold,
+                nms_threshold,
+            )?;
+            probability_map.stitch_max(&result.probability_map, slice.y)?;
+            offset_speech_bubble_result(&mut result, slice.y);
+            regions.extend(result.regions);
+        }
+
+        Ok(Some(SpeechBubbleSegmentationResult {
+            image_width: image.width(),
+            image_height: image.height(),
+            regions: dedupe_speech_bubble_regions(regions),
+            probability_map,
+        }))
     }
 
     fn preprocess(&self, image: &DynamicImage) -> Result<PreparedInput> {
@@ -307,6 +364,36 @@ impl SpeechBubbleSegmentation {
             scale,
         })
     }
+}
+
+fn offset_speech_bubble_result(result: &mut SpeechBubbleSegmentationResult, offset_y: u32) {
+    for region in &mut result.regions {
+        region.bbox[1] += offset_y as f32;
+        region.bbox[3] += offset_y as f32;
+        region.mask.y = region.mask.y.saturating_add(offset_y);
+    }
+}
+
+fn dedupe_speech_bubble_regions(mut regions: Vec<SpeechBubbleRegion>) -> Vec<SpeechBubbleRegion> {
+    regions.sort_by(|a, b| {
+        b.area
+            .cmp(&a.area)
+            .then_with(|| b.score.total_cmp(&a.score))
+    });
+    let mut out: Vec<SpeechBubbleRegion> = Vec::with_capacity(regions.len());
+    for region in regions {
+        if out
+            .iter()
+            .all(|existing| !speech_bubble_regions_duplicate(existing, &region))
+        {
+            out.push(region);
+        }
+    }
+    out
+}
+
+fn speech_bubble_regions_duplicate(a: &SpeechBubbleRegion, b: &SpeechBubbleRegion) -> bool {
+    bbox_is_duplicate(a.bbox, b.bbox)
 }
 
 pub async fn prefetch(runtime: &RuntimeManager) -> Result<()> {

--- a/koharu/src/assets.rs
+++ b/koharu/src/assets.rs
@@ -35,8 +35,8 @@ pub fn from_context<R: tauri::Runtime>(context: &mut tauri::Context<R>) -> Asset
             }
             // Tauri stores bundled asset keys with a leading slash while the
             // axum fallback can request relative paths.
-            let path = format!("/{path}");
-            let key = tauri::utils::assets::AssetKey::from(path.as_str());
+            let prefixed = format!("/{path}");
+            let key = tauri::utils::assets::AssetKey::from(prefixed.as_str());
             assets.get(&key)
         })?;
         let bytes = asset.into_owned();

--- a/koharu/src/assets.rs
+++ b/koharu/src/assets.rs
@@ -29,7 +29,17 @@ pub fn from_context<R: tauri::Runtime>(context: &mut tauri::Context<R>) -> Asset
 
     Arc::new(move |path: &str| {
         let key = tauri::utils::assets::AssetKey::from(path);
-        let bytes = assets.get(&key)?.into_owned();
+        let asset = assets.get(&key).or_else(|| {
+            if path.starts_with('/') {
+                return None;
+            }
+            // Tauri stores bundled asset keys with a leading slash while the
+            // axum fallback can request relative paths.
+            let path = format!("/{path}");
+            let key = tauri::utils::assets::AssetKey::from(path.as_str());
+            assets.get(&key)
+        })?;
+        let bytes = asset.into_owned();
         let mime = tauri::utils::mime_type::MimeType::parse(&bytes, path);
         Some((bytes, mime))
     })


### PR DESCRIPTION
## Summary

- Add shared vertical slicing for very tall pages and use it across text detection, layout detection, speech-bubble segmentation, manga text segmentation, and Flux inpainting.
- Stitch sliced probability maps/masks with max blending, offset/dedupe detected regions, and keep inpainting scoped to masked slices before compositing back.
- Fall back from WebP to PNG for oversized image dimensions so rendered/inpainted outputs can be stored for long strips.
- Fix embedded asset lookup so the headless Web UI can serve bundled assets consistently.

## User-visible behavior changes

- Very tall manga strip images should no longer fail or over-resize as often during detection, segmentation, inpainting, and final render storage.
- Long-page processing may run as multiple internal slice passes, but the page remains a single imported page and the resulting masks, detections, inpainted image, and rendered image are stitched back into the original coordinate space.
- Oversized rendered/inpainted blobs may be stored as PNG instead of WebP when WebP dimension limits would reject the image; loading and export paths still decode the stored image normally.

## Root Cause

Very tall manga strips were being passed through several engines as one oversized frame. Some models resized the whole page too aggressively, some inpainting paths formed huge crops, and WebP encoding cannot handle dimensions above its limit. That made detect/OCR-adjacent segmentation/inpaint/render flows fail or become impractically slow on long images.

## Verification

- Ran `cargo fmt -- --check`
- Ran `git diff --check`
- Ran `koharu-ml` unit tests in a Linux build container
- Ran oversized WebP fallback test for `koharu-app`
- Smoke-tested the headless Web UI at `/` and `/api/v1/config`

## AI assistance

AI assistance was used to prepare this draft patch. The PR is intentionally kept as a draft until the contributor reviews and understands the changes before submission for maintainer review.