### PR TITLE
fix: fix bug where progress indicator doesn't progress

### DIFF
--- a/crates/koharu-app/src/pipeline/mod.rs
+++ b/crates/koharu-app/src/pipeline/mod.rs
@@ -171,6 +171,7 @@ pub async fn run(
                     total_pages,
                     overall_percent: percent,
                 });
+                tokio::task::yield_now().await;
             }
 
             // The page must still exist (user may have deleted it mid-run).


### PR DESCRIPTION
The progress indicator for me frequently fails to update. Adding a manual yield to the scheduler appears to fix this.

No AI was used in the production of this MR.