### PR TITLE
chore(dev): Switched to Microsoft recommended way of finding MSVC

### DIFF
--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -62,26 +62,20 @@ async function setupCuda() {
 }
 
 async function setupCl() {
-  const vsRoots = [
-    'C:/Program Files/Microsoft Visual Studio',
-    'C:/Program Files (x86)/Microsoft Visual Studio',
-  ]
-  const editions = ['Community', 'Professional', 'Enterprise', 'BuildTools']
-
-  for (const vsRoot of vsRoots) {
-    const vsVersions = await readdir(vsRoot).catch(() => [])
-
-    for (const vsVersion of vsVersions) {
-      for (const edition of editions) {
-        const vcPath = path.join(vsRoot, vsVersion, edition, 'VC/Tools/MSVC')
-        if (await pathExists(vcPath)) {
-          const msvcVersions = await readdir(vcPath)
-          for (const msvcVersion of msvcVersions) {
-            const binPath = path.join(vcPath, msvcVersion, 'bin/Hostx64/x64')
-            if (await pathExists(binPath)) {
-              process.env.PATH = `${binPath}${path.delimiter}${process.env.PATH}`
-              return
-            }
+  if (await pathExists("C:/Program Files (x86)/Microsoft Visual Studio/Installer/")) {
+    // This is the microsoft-approved way to discover VS installations. Microsoft guarantees vswhere will be at this path.
+    const { stdout, stderr } = await exec('vswhere -latest -prerelease -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath',
+      { env: process.env, cwd: "C:/Program Files (x86)/Microsoft Visual Studio/Installer/" })
+    const vsRoot = stdout.trim()
+    if (vsRoot !== "") {
+      const vcPath = path.join(vsRoot, 'VC/Tools/MSVC')
+      if (await pathExists(vcPath)) {
+        const msvcVersions = await readdir(vcPath)
+        for (const msvcVersion of msvcVersions) {
+          const binPath = path.join(vcPath, msvcVersion, 'bin/Hostx64/x64')
+          if (await pathExists(binPath)) {
+            process.env.PATH = `${binPath}${path.delimiter}${process.env.PATH}`
+            return
           }
         }
       }


### PR DESCRIPTION
`vswhere` is the standard tool for finding VS installations. Switch to using that. This also allows us to support VS Insiders.

No AI was used in the creation of this MR.